### PR TITLE
feat: implementar auth JWT, CRUD completo e rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,11 @@ DB_PASSWORD=your-db-password
 DB_NAME=postgres
 DB_SSL_MODE=require      # require for Supabase, disable for local
 
+
+# ----- Admin -----
+ADMIN_EMAIL=admin@aprovacards.com
+ADMIN_PASSWORD=change-this-password
+
 # ----- JWT -----
 JWT_SECRET=generate-a-strong-secret-here
 JWT_EXPIRATION=3600

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -16,25 +16,27 @@ import (
 )
 
 func main() {
-	// Carregar configuração
 	cfg := config.Load()
 
-	// Conectar ao banco
 	db := connectDatabase(cfg)
 
-	// Setup Gin
-	engine := gin.Default()
+	if cfg.Server.Env == "production" {
+		gin.SetMode(gin.ReleaseMode)
+	}
+	engine := gin.New()
+	engine.Use(gin.Recovery())
 
-	// Middlewares
+	// Global middlewares
 	engine.Use(middleware.RequestLogger())
 	engine.Use(middleware.ErrorHandler())
 	engine.Use(middleware.CORSMiddleware(cfg.CORS.AllowedOrigins))
-	engine.Use(middleware.RateLimitMiddleware())
 
-	// Injeção de dependências e rotas
-	setupRoutes(engine, db)
+	// Global rate limiter: 100 req/min per IP
+	globalLimiter := middleware.NewRateLimiter(cfg.RateLimit.Requests, cfg.RateLimit.WindowSeconds)
+	engine.Use(middleware.RateLimitByIP(globalLimiter))
 
-	// Iniciar servidor
+	setupRoutes(engine, db, cfg)
+
 	port := ":" + cfg.Server.Port
 	fmt.Printf("🚀 Server running on http://localhost%s\n", port)
 
@@ -46,10 +48,14 @@ func main() {
 func connectDatabase(cfg *config.Config) *gorm.DB {
 	dsn := cfg.GetDSN()
 
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Info),
-	})
+	logMode := logger.Info
+	if cfg.Server.Env == "production" {
+		logMode = logger.Warn
+	}
 
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+		Logger: logger.Default.LogMode(logMode),
+	})
 	if err != nil {
 		log.Fatalf("failed to connect to database: %v", err)
 	}
@@ -58,25 +64,109 @@ func connectDatabase(cfg *config.Config) *gorm.DB {
 	return db
 }
 
-func setupRoutes(engine *gin.Engine, db *gorm.DB) {
+func setupRoutes(engine *gin.Engine, db *gorm.DB, cfg *config.Config) {
 	api := engine.Group("/api/v1")
 
-	// Health check - Sem autenticação, com verificação real do banco
+	// ---- Health (public) ----
 	healthHandler := handlers.NewHealthHandler(db)
 	api.GET("/health", healthHandler.Check)
 
-	// Sample routes - Exemplo de CRUD completo com Handler -> UseCase -> Repository
-	sampleRepo := repositories.NewSampleRepository(db)
-	sampleUseCase := usecases.NewSampleUseCase(sampleRepo)
-	sampleHandler := handlers.NewSampleHandler(sampleUseCase)
+	// ---- Auth (public, stricter rate limit: 5 req / 5 min) ----
+	authLimiter := middleware.NewRateLimiter(5, 300)
+	mentorRepo := repositories.NewMentorRepository(db)
+	authUC := usecases.NewAuthUseCase(mentorRepo, cfg.Admin.Email, cfg.Admin.Password)
+	authHandler := handlers.NewAuthHandler(authUC, cfg.JWT.Secret, cfg.JWT.Expiration)
 
-	samples := api.Group("/samples")
+	authGroup := api.Group("/auth")
+	authGroup.Use(middleware.RateLimitByIP(authLimiter))
 	{
-		samples.POST("", sampleHandler.Create)       // POST /api/v1/samples
-		samples.GET("", sampleHandler.GetAll)        // GET /api/v1/samples?page=1&page_size=10
-		samples.GET("/:id", sampleHandler.GetByID)   // GET /api/v1/samples/:id
-		samples.PUT("/:id", sampleHandler.Update)    // PUT /api/v1/samples/:id
-		samples.DELETE("/:id", sampleHandler.Delete) // DELETE /api/v1/samples/:id
+		authGroup.POST("/admin-login", authHandler.AdminLogin)
+	}
+
+	// ---- Feedback (public for students via X-Student-Email header) ----
+	feedbackRepo := repositories.NewFeedbackRepository(db)
+	feedbackHandler := handlers.NewFeedbackHandler(feedbackRepo)
+	api.POST("/feedbacks", feedbackHandler.Create)
+
+	// ---- Protected routes (JWT required) ----
+	protected := api.Group("")
+	protected.Use(middleware.AuthMiddleware(cfg.JWT.Secret))
+	{
+		// -- Mentors (admin only) --
+		mentorUC := usecases.NewMentorUseCase(mentorRepo)
+		mentorHandler := handlers.NewMentorHandler(mentorUC)
+		mentors := protected.Group("/mentors")
+		mentors.Use(middleware.AdminOnly())
+		{
+			mentors.POST("", mentorHandler.Create)
+			mentors.GET("", mentorHandler.GetAll)
+			mentors.GET("/:id", mentorHandler.GetByID)
+			mentors.PUT("/:id", mentorHandler.Update)
+			mentors.DELETE("/:id", mentorHandler.Delete)
+		}
+
+		// -- Products (admin/mentor) --
+		productRepo := repositories.NewProductRepository(db)
+		productUC := usecases.NewProductUseCase(productRepo)
+		productHandler := handlers.NewProductHandler(productUC)
+		products := protected.Group("/products")
+		{
+			products.POST("", productHandler.Create)
+			products.GET("", productHandler.GetAll)
+			products.GET("/:id", productHandler.GetByID)
+			products.PUT("/:id", productHandler.Update)
+			products.DELETE("/:id", productHandler.Delete)
+		}
+
+		// -- Disciplines within product (separate group to avoid wildcard conflict) --
+		discRepo := repositories.NewDisciplineRepository(db)
+		discUC := usecases.NewDisciplineUseCase(discRepo)
+		discHandler := handlers.NewDisciplineHandler(discUC)
+		protected.GET("/products/:id/disciplines", discHandler.GetByProductID)
+		protected.POST("/products/:id/disciplines", discHandler.Create)
+
+		// -- Students within product --
+		studentRepo := repositories.NewStudentAccessRepository(db)
+		studentHandler := handlers.NewStudentHandler(studentRepo)
+		protected.GET("/products/:id/students", studentHandler.GetByProductID)
+		protected.POST("/products/:id/students", studentHandler.AddStudent)
+
+		// -- Feedbacks for product --
+		protected.GET("/products/:id/feedbacks", feedbackHandler.GetByProductID)
+
+		// -- Disciplines (standalone) --
+		discRepo2 := repositories.NewDisciplineRepository(db)
+		discUC2 := usecases.NewDisciplineUseCase(discRepo2)
+		discHandler2 := handlers.NewDisciplineHandler(discUC2)
+		disciplines := protected.Group("/disciplines")
+		{
+			disciplines.PUT("/:id", discHandler2.Update)
+			disciplines.DELETE("/:id", discHandler2.Delete)
+			disciplines.POST("/:id/reorder", discHandler2.Reorder)
+		}
+
+		// -- Cards within discipline --
+		cardRepo := repositories.NewCardRepository(db)
+		cardUC := usecases.NewCardUseCase(cardRepo, discRepo2)
+		cardHandler := handlers.NewCardHandler(cardUC)
+		protected.GET("/disciplines/:id/cards", cardHandler.GetByDisciplineID)
+		protected.POST("/disciplines/:id/cards", cardHandler.Create)
+
+		// -- Cards (standalone) --
+		cardRepo2 := repositories.NewCardRepository(db)
+		discRepo3 := repositories.NewDisciplineRepository(db)
+		cardUC2 := usecases.NewCardUseCase(cardRepo2, discRepo3)
+		cardHandler2 := handlers.NewCardHandler(cardUC2)
+		cards := protected.Group("/cards")
+		{
+			cards.PUT("/:id", cardHandler2.Update)
+			cards.DELETE("/:id", cardHandler2.Delete)
+		}
+
+		// -- Students (standalone) --
+		studentRepo2 := repositories.NewStudentAccessRepository(db)
+		studentHandler2 := handlers.NewStudentHandler(studentRepo2)
+		protected.PATCH("/students/:email/access", studentHandler2.UpdateAccess)
 	}
 
 	fmt.Println("✅ Routes registered successfully")

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -9,6 +9,7 @@ import (
 )
 
 type Config struct {
+	Admin     AdminConfig
 	Server    ServerConfig
 	Database  DatabaseConfig
 	JWT       JWTConfig
@@ -68,6 +69,10 @@ func Load() *Config {
 		CORS: CORSConfig{
 			AllowedOrigins: getEnv("CORS_ALLOWED_ORIGINS", "http://localhost:3000"),
 		},
+		Admin: AdminConfig{
+			Email:    getEnv("ADMIN_EMAIL", "admin@aprovacards.com"),
+			Password: getEnv("ADMIN_PASSWORD", "admin123"),
+		},
 		RateLimit: RateLimitConfig{
 			Enabled:       getEnvBool("RATE_LIMIT_ENABLED", true),
 			Requests:      getEnvInt("RATE_LIMIT_REQUESTS", 100),
@@ -108,4 +113,9 @@ func getEnvBool(key string, defaultVal bool) bool {
 		return defaultVal
 	}
 	return val == "true" || val == "1" || val == "yes"
+}
+
+type AdminConfig struct {
+	Email    string
+	Password string
 }

--- a/backend/internal/dto/auth_dto.go
+++ b/backend/internal/dto/auth_dto.go
@@ -1,0 +1,18 @@
+package dto
+
+type AdminLoginRequest struct {
+	Email    string `json:"email" binding:"required,email"`
+	Password string `json:"password" binding:"required,min=1"`
+}
+
+type LoginResponse struct {
+	Token string      `json:"token"`
+	User  interface{} `json:"user"`
+}
+
+type UserInfo struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+	Role  string `json:"role"`
+	Name  string `json:"name"`
+}

--- a/backend/internal/dto/card_dto.go
+++ b/backend/internal/dto/card_dto.go
@@ -1,0 +1,24 @@
+package dto
+
+type CreateCardRequest struct {
+	DisciplineID string `json:"discipline_id" binding:"required"`
+	Front        string `json:"front" binding:"required,min=1"`
+	Back         string `json:"back" binding:"required,min=1"`
+	Order        int    `json:"order"`
+}
+
+type UpdateCardRequest struct {
+	Front string `json:"front"`
+	Back  string `json:"back"`
+	Order *int   `json:"order"`
+}
+
+type CardResponse struct {
+	ID           string `json:"id"`
+	DisciplineID string `json:"discipline_id"`
+	ProductID    string `json:"product_id"`
+	Front        string `json:"front"`
+	Back         string `json:"back"`
+	Order        int    `json:"order"`
+	CreatedAt    string `json:"created_at"`
+}

--- a/backend/internal/dto/discipline_dto.go
+++ b/backend/internal/dto/discipline_dto.go
@@ -1,0 +1,24 @@
+package dto
+
+type CreateDisciplineRequest struct {
+	ProductID string `json:"product_id" binding:"required"`
+	Name      string `json:"name" binding:"required,min=2"`
+	Order     int    `json:"order"`
+}
+
+type UpdateDisciplineRequest struct {
+	Name  string `json:"name"`
+	Order *int   `json:"order"`
+}
+
+type ReorderDisciplinesRequest struct {
+	IDs []string `json:"ids" binding:"required,min=1"`
+}
+
+type DisciplineResponse struct {
+	ID        string `json:"id"`
+	ProductID string `json:"product_id"`
+	Name      string `json:"name"`
+	Order     int    `json:"order"`
+	CreatedAt string `json:"created_at"`
+}

--- a/backend/internal/dto/feedback_dto.go
+++ b/backend/internal/dto/feedback_dto.go
@@ -1,0 +1,16 @@
+package dto
+
+type CreateFeedbackRequest struct {
+	ProductID       string `json:"product_id" binding:"required"`
+	Mensagem        string `json:"mensagem" binding:"required,min=5"`
+	TotalCardsEpoca int    `json:"total_cards_epoca"`
+}
+
+type FeedbackResponse struct {
+	ID              string `json:"id"`
+	StudentEmail    string `json:"student_email"`
+	ProductID       string `json:"product_id"`
+	Mensagem        string `json:"mensagem"`
+	TotalCardsEpoca int    `json:"total_cards_epoca"`
+	CriadoEm        string `json:"criado_em"`
+}

--- a/backend/internal/dto/mentor_dto.go
+++ b/backend/internal/dto/mentor_dto.go
@@ -1,0 +1,33 @@
+package dto
+
+type CreateMentorRequest struct {
+	Name           string  `json:"name" binding:"required,min=3"`
+	Email          string  `json:"email" binding:"required,email"`
+	Slug           string  `json:"slug" binding:"required,min=3"`
+	MentorPassword string  `json:"mentor_password" binding:"required,min=4"`
+	PrimaryColor   string  `json:"primary_color"`
+	SecondaryColor string  `json:"secondary_color"`
+	LogoURL        *string `json:"logo_url"`
+}
+
+type UpdateMentorRequest struct {
+	Name           string  `json:"name"`
+	Email          string  `json:"email"`
+	Slug           string  `json:"slug"`
+	MentorPassword string  `json:"mentor_password"`
+	PrimaryColor   string  `json:"primary_color"`
+	SecondaryColor string  `json:"secondary_color"`
+	LogoURL        *string `json:"logo_url"`
+}
+
+type MentorResponse struct {
+	ID             string  `json:"id"`
+	Name           string  `json:"name"`
+	Email          string  `json:"email"`
+	Slug           string  `json:"slug"`
+	LogoURL        *string `json:"logo_url"`
+	PrimaryColor   string  `json:"primary_color"`
+	SecondaryColor string  `json:"secondary_color"`
+	AccentColor    *string `json:"accent_color"`
+	CreatedAt      string  `json:"created_at"`
+}

--- a/backend/internal/dto/product_dto.go
+++ b/backend/internal/dto/product_dto.go
@@ -1,0 +1,25 @@
+package dto
+
+type CreateProductRequest struct {
+	MentorID   string  `json:"mentor_id" binding:"required"`
+	Name       string  `json:"name" binding:"required,min=3"`
+	AccessCode string  `json:"access_code" binding:"required,min=4"`
+	CoverImageURL *string `json:"cover_image_url"`
+}
+
+type UpdateProductRequest struct {
+	Name          string  `json:"name"`
+	AccessCode    string  `json:"access_code"`
+	Active        *bool   `json:"active"`
+	CoverImageURL *string `json:"cover_image_url"`
+}
+
+type ProductResponse struct {
+	ID            string  `json:"id"`
+	MentorID      string  `json:"mentor_id"`
+	Name          string  `json:"name"`
+	AccessCode    string  `json:"access_code"`
+	Active        bool    `json:"active"`
+	CoverImageURL *string `json:"cover_image_url"`
+	CreatedAt     string  `json:"created_at"`
+}

--- a/backend/internal/dto/session_dto.go
+++ b/backend/internal/dto/session_dto.go
@@ -1,0 +1,26 @@
+package dto
+
+type CreateSessionRequest struct {
+	ProductID    string  `json:"product_id" binding:"required"`
+	DisciplineID *string `json:"discipline_id"`
+}
+
+type CompleteSessionRequest struct {
+	CardsReviewed    int `json:"cards_reviewed"`
+	Correct          int `json:"correct"`
+	Incorrect        int `json:"incorrect"`
+	StudyTimeSeconds int `json:"study_time_seconds"`
+}
+
+type SessionResponse struct {
+	ID               string  `json:"id"`
+	StudentEmail     string  `json:"student_email"`
+	ProductID        string  `json:"product_id"`
+	DisciplineID     *string `json:"discipline_id"`
+	CardsReviewed    int     `json:"cards_reviewed"`
+	Correct          int     `json:"correct"`
+	Incorrect        int     `json:"incorrect"`
+	StudyTimeSeconds int     `json:"study_time_seconds"`
+	SessionDate      string  `json:"session_date"`
+	CreatedAt        string  `json:"created_at"`
+}

--- a/backend/internal/dto/student_dto.go
+++ b/backend/internal/dto/student_dto.go
@@ -1,0 +1,25 @@
+package dto
+
+type AddStudentRequest struct {
+	Email string `json:"email" binding:"required,email"`
+}
+
+type UpdateStudentAccessRequest struct {
+	Active         bool    `json:"active"`
+	InactiveReason *string `json:"inactive_reason"`
+}
+
+type StudentAccessResponse struct {
+	ID             string  `json:"id"`
+	Email          string  `json:"email"`
+	ProductID      string  `json:"product_id"`
+	Active         bool    `json:"active"`
+	InactiveReason *string `json:"inactive_reason"`
+	CreatedAt      string  `json:"created_at"`
+}
+
+type SyncProgressRequest struct {
+	CardID     string `json:"card_id" binding:"required"`
+	Difficulty string `json:"difficulty" binding:"required,oneof=errei dificil medio facil"`
+	Status     string `json:"status"`
+}

--- a/backend/internal/handlers/auth_handler.go
+++ b/backend/internal/handlers/auth_handler.go
@@ -1,0 +1,35 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/approva-cards/back-aprova-cards/internal/dto"
+	"github.com/approva-cards/back-aprova-cards/internal/usecases"
+	"github.com/gin-gonic/gin"
+)
+
+type AuthHandler struct {
+	usecase   usecases.AuthUseCase
+	jwtSecret string
+	jwtExp    int
+}
+
+func NewAuthHandler(usecase usecases.AuthUseCase, jwtSecret string, jwtExp int) *AuthHandler {
+	return &AuthHandler{usecase: usecase, jwtSecret: jwtSecret, jwtExp: jwtExp}
+}
+
+func (h *AuthHandler) AdminLogin(c *gin.Context) {
+	var req dto.AdminLoginRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()})
+		return
+	}
+
+	response, err := h.usecase.AdminLogin(&req, h.jwtSecret, h.jwtExp)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, dto.APIResponse{Success: false, Error: "invalid credentials"})
+		return
+	}
+
+	c.JSON(http.StatusOK, dto.APIResponse{Success: true, Data: response, Message: "Login successful"})
+}

--- a/backend/internal/handlers/card_handler.go
+++ b/backend/internal/handlers/card_handler.go
@@ -1,0 +1,44 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/approva-cards/back-aprova-cards/internal/dto"
+	"github.com/approva-cards/back-aprova-cards/internal/usecases"
+	"github.com/gin-gonic/gin"
+)
+
+type CardHandler struct{ usecase usecases.CardUseCase }
+
+func NewCardHandler(uc usecases.CardUseCase) *CardHandler { return &CardHandler{usecase: uc} }
+
+func (h *CardHandler) Create(c *gin.Context) {
+	var req dto.CreateCardRequest
+	if err := c.ShouldBindJSON(&req); err != nil { c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	if req.DisciplineID == "" { req.DisciplineID = c.Param("id") }
+	r, err := h.usecase.Create(&req, "")
+	if err != nil { c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	c.JSON(http.StatusCreated, dto.APIResponse{Success: true, Data: r, Message: "Card created"})
+}
+
+func (h *CardHandler) GetByDisciplineID(c *gin.Context) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	ps, _ := strconv.Atoi(c.DefaultQuery("page_size", "20"))
+	r, err := h.usecase.GetByDisciplineID(c.Param("id"), page, ps)
+	if err != nil { c.JSON(http.StatusInternalServerError, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	c.JSON(http.StatusOK, dto.APIResponse{Success: true, Data: r})
+}
+
+func (h *CardHandler) Update(c *gin.Context) {
+	var req dto.UpdateCardRequest
+	if err := c.ShouldBindJSON(&req); err != nil { c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	r, err := h.usecase.Update(c.Param("id"), &req)
+	if err != nil { c.JSON(http.StatusNotFound, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	c.JSON(http.StatusOK, dto.APIResponse{Success: true, Data: r, Message: "Card updated"})
+}
+
+func (h *CardHandler) Delete(c *gin.Context) {
+	if err := h.usecase.Delete(c.Param("id")); err != nil { c.JSON(http.StatusNotFound, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	c.JSON(http.StatusNoContent, nil)
+}

--- a/backend/internal/handlers/discipline_handler.go
+++ b/backend/internal/handlers/discipline_handler.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/approva-cards/back-aprova-cards/internal/dto"
+	"github.com/approva-cards/back-aprova-cards/internal/usecases"
+	"github.com/gin-gonic/gin"
+)
+
+type DisciplineHandler struct{ usecase usecases.DisciplineUseCase }
+
+func NewDisciplineHandler(uc usecases.DisciplineUseCase) *DisciplineHandler { return &DisciplineHandler{usecase: uc} }
+
+func (h *DisciplineHandler) Create(c *gin.Context) {
+	var req dto.CreateDisciplineRequest
+	if err := c.ShouldBindJSON(&req); err != nil { c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	if req.ProductID == "" { req.ProductID = c.Param("id") }
+	r, err := h.usecase.Create(&req)
+	if err != nil { c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	c.JSON(http.StatusCreated, dto.APIResponse{Success: true, Data: r, Message: "Discipline created"})
+}
+
+func (h *DisciplineHandler) GetByProductID(c *gin.Context) {
+	r, err := h.usecase.GetByProductID(c.Param("id"))
+	if err != nil { c.JSON(http.StatusInternalServerError, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	c.JSON(http.StatusOK, dto.APIResponse{Success: true, Data: r})
+}
+
+func (h *DisciplineHandler) Update(c *gin.Context) {
+	var req dto.UpdateDisciplineRequest
+	if err := c.ShouldBindJSON(&req); err != nil { c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	r, err := h.usecase.Update(c.Param("id"), &req)
+	if err != nil { c.JSON(http.StatusNotFound, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	c.JSON(http.StatusOK, dto.APIResponse{Success: true, Data: r, Message: "Discipline updated"})
+}
+
+func (h *DisciplineHandler) Delete(c *gin.Context) {
+	if err := h.usecase.Delete(c.Param("id")); err != nil { c.JSON(http.StatusNotFound, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	c.JSON(http.StatusNoContent, nil)
+}
+
+func (h *DisciplineHandler) Reorder(c *gin.Context) {
+	var req dto.ReorderDisciplinesRequest
+	if err := c.ShouldBindJSON(&req); err != nil { c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	r, err := h.usecase.Reorder(c.Param("id"), &req)
+	if err != nil { c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	c.JSON(http.StatusOK, dto.APIResponse{Success: true, Data: r, Message: "Disciplines reordered"})
+}

--- a/backend/internal/handlers/feedback_handler.go
+++ b/backend/internal/handlers/feedback_handler.go
@@ -1,0 +1,44 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/approva-cards/back-aprova-cards/internal/dto"
+	"github.com/approva-cards/back-aprova-cards/internal/models"
+	"github.com/approva-cards/back-aprova-cards/internal/repositories"
+	"github.com/gin-gonic/gin"
+)
+
+type FeedbackHandler struct{ repo repositories.FeedbackRepository }
+
+func NewFeedbackHandler(repo repositories.FeedbackRepository) *FeedbackHandler {
+	return &FeedbackHandler{repo: repo}
+}
+
+func (h *FeedbackHandler) Create(c *gin.Context) {
+	var req dto.CreateFeedbackRequest
+	if err := c.ShouldBindJSON(&req); err != nil { c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	email, _ := c.Get("user_email")
+	emailStr, ok := email.(string)
+	if !ok || emailStr == "" { emailStr = c.GetHeader("X-Student-Email") }
+	if emailStr == "" { c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: "student email required"}); return }
+
+	e := &models.StudentFeedback{StudentEmail: emailStr, ProductID: req.ProductID, Mensagem: req.Mensagem, TotalCardsEpoca: req.TotalCardsEpoca}
+	if err := h.repo.Create(e); err != nil { c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	c.JSON(http.StatusCreated, dto.APIResponse{Success: true, Message: "Feedback submitted"})
+}
+
+func (h *FeedbackHandler) GetByProductID(c *gin.Context) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	ps, _ := strconv.Atoi(c.DefaultQuery("page_size", "20"))
+	entities, total, err := h.repo.GetByProductID(c.Param("id"), page, ps)
+	if err != nil { c.JSON(http.StatusInternalServerError, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	if ps < 1 { ps = 20 }
+	var r []dto.FeedbackResponse
+	for _, e := range entities {
+		r = append(r, dto.FeedbackResponse{ID: e.ID, StudentEmail: e.StudentEmail, ProductID: e.ProductID, Mensagem: e.Mensagem, TotalCardsEpoca: e.TotalCardsEpoca, CriadoEm: e.CriadoEm.Format("2006-01-02T15:04:05Z")})
+	}
+	tp := int(total) / ps; if int(total)%ps > 0 { tp++ }
+	c.JSON(http.StatusOK, dto.APIResponse{Success: true, Data: dto.PaginatedResponse{Data: r, Total: total, Page: page, PageSize: ps, TotalPages: tp}})
+}

--- a/backend/internal/handlers/mentor_handler.go
+++ b/backend/internal/handlers/mentor_handler.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/approva-cards/back-aprova-cards/internal/dto"
+	"github.com/approva-cards/back-aprova-cards/internal/usecases"
+	"github.com/gin-gonic/gin"
+)
+
+type MentorHandler struct{ usecase usecases.MentorUseCase }
+
+func NewMentorHandler(usecase usecases.MentorUseCase) *MentorHandler {
+	return &MentorHandler{usecase: usecase}
+}
+
+func (h *MentorHandler) Create(c *gin.Context) {
+	var req dto.CreateMentorRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()})
+		return
+	}
+	r, err := h.usecase.Create(&req)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, dto.APIResponse{Success: true, Data: r, Message: "Mentor created"})
+}
+
+func (h *MentorHandler) GetAll(c *gin.Context) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "10"))
+	r, err := h.usecase.GetAll(page, pageSize)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, dto.APIResponse{Success: false, Error: err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, dto.APIResponse{Success: true, Data: r})
+}
+
+func (h *MentorHandler) GetByID(c *gin.Context) {
+	r, err := h.usecase.GetByID(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusNotFound, dto.APIResponse{Success: false, Error: err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, dto.APIResponse{Success: true, Data: r})
+}
+
+func (h *MentorHandler) Update(c *gin.Context) {
+	var req dto.UpdateMentorRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()})
+		return
+	}
+	r, err := h.usecase.Update(c.Param("id"), &req)
+	if err != nil {
+		c.JSON(http.StatusNotFound, dto.APIResponse{Success: false, Error: err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, dto.APIResponse{Success: true, Data: r, Message: "Mentor updated"})
+}
+
+func (h *MentorHandler) Delete(c *gin.Context) {
+	if err := h.usecase.Delete(c.Param("id")); err != nil {
+		c.JSON(http.StatusNotFound, dto.APIResponse{Success: false, Error: err.Error()})
+		return
+	}
+	c.JSON(http.StatusNoContent, nil)
+}

--- a/backend/internal/handlers/product_handler.go
+++ b/backend/internal/handlers/product_handler.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/approva-cards/back-aprova-cards/internal/dto"
+	"github.com/approva-cards/back-aprova-cards/internal/usecases"
+	"github.com/gin-gonic/gin"
+)
+
+type ProductHandler struct{ usecase usecases.ProductUseCase }
+
+func NewProductHandler(uc usecases.ProductUseCase) *ProductHandler { return &ProductHandler{usecase: uc} }
+
+func (h *ProductHandler) Create(c *gin.Context) {
+	var req dto.CreateProductRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()})
+		return
+	}
+	r, err := h.usecase.Create(&req)
+	if err != nil { c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	c.JSON(http.StatusCreated, dto.APIResponse{Success: true, Data: r, Message: "Product created"})
+}
+
+func (h *ProductHandler) GetAll(c *gin.Context) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	ps, _ := strconv.Atoi(c.DefaultQuery("page_size", "10"))
+	mentorID := c.Query("mentor_id")
+	var r *dto.PaginatedResponse
+	var err error
+	if mentorID != "" {
+		r, err = h.usecase.GetByMentorID(mentorID, page, ps)
+	} else {
+		r, err = h.usecase.GetAll(page, ps)
+	}
+	if err != nil { c.JSON(http.StatusInternalServerError, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	c.JSON(http.StatusOK, dto.APIResponse{Success: true, Data: r})
+}
+
+func (h *ProductHandler) GetByID(c *gin.Context) {
+	r, err := h.usecase.GetByID(c.Param("id"))
+	if err != nil { c.JSON(http.StatusNotFound, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	c.JSON(http.StatusOK, dto.APIResponse{Success: true, Data: r})
+}
+
+func (h *ProductHandler) Update(c *gin.Context) {
+	var req dto.UpdateProductRequest
+	if err := c.ShouldBindJSON(&req); err != nil { c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	r, err := h.usecase.Update(c.Param("id"), &req)
+	if err != nil { c.JSON(http.StatusNotFound, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	c.JSON(http.StatusOK, dto.APIResponse{Success: true, Data: r, Message: "Product updated"})
+}
+
+func (h *ProductHandler) Delete(c *gin.Context) {
+	if err := h.usecase.Delete(c.Param("id")); err != nil { c.JSON(http.StatusNotFound, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	c.JSON(http.StatusNoContent, nil)
+}

--- a/backend/internal/handlers/student_handler.go
+++ b/backend/internal/handlers/student_handler.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/approva-cards/back-aprova-cards/internal/dto"
+	"github.com/approva-cards/back-aprova-cards/internal/models"
+	"github.com/approva-cards/back-aprova-cards/internal/repositories"
+	"github.com/gin-gonic/gin"
+)
+
+type StudentHandler struct{ repo repositories.StudentAccessRepository }
+
+func NewStudentHandler(repo repositories.StudentAccessRepository) *StudentHandler {
+	return &StudentHandler{repo: repo}
+}
+
+func (h *StudentHandler) GetByProductID(c *gin.Context) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	ps, _ := strconv.Atoi(c.DefaultQuery("page_size", "20"))
+	entities, total, err := h.repo.GetByProductID(c.Param("id"), page, ps)
+	if err != nil { c.JSON(http.StatusInternalServerError, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	if ps < 1 { ps = 20 }
+	var r []dto.StudentAccessResponse
+	for _, e := range entities {
+		r = append(r, dto.StudentAccessResponse{ID: e.ID, Email: e.Email, ProductID: e.ProductID, Active: e.Active, InactiveReason: e.InactiveReason, CreatedAt: e.CreatedAt.Format("2006-01-02T15:04:05Z")})
+	}
+	tp := int(total) / ps; if int(total)%ps > 0 { tp++ }
+	c.JSON(http.StatusOK, dto.APIResponse{Success: true, Data: dto.PaginatedResponse{Data: r, Total: total, Page: page, PageSize: ps, TotalPages: tp}})
+}
+
+func (h *StudentHandler) AddStudent(c *gin.Context) {
+	var req dto.AddStudentRequest
+	if err := c.ShouldBindJSON(&req); err != nil { c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	productID := c.Param("id")
+	existing, _ := h.repo.GetByEmailAndProduct(req.Email, productID)
+	if existing != nil {
+		c.JSON(http.StatusConflict, dto.APIResponse{Success: false, Error: "student already has access"})
+		return
+	}
+	e := &models.StudentAccess{Email: req.Email, ProductID: productID, Active: true}
+	if err := h.repo.Create(e); err != nil { c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	c.JSON(http.StatusCreated, dto.APIResponse{Success: true, Data: dto.StudentAccessResponse{ID: e.ID, Email: e.Email, ProductID: e.ProductID, Active: e.Active, CreatedAt: e.CreatedAt.Format("2006-01-02T15:04:05Z")}, Message: "Student added"})
+}
+
+func (h *StudentHandler) UpdateAccess(c *gin.Context) {
+	var req dto.UpdateStudentAccessRequest
+	if err := c.ShouldBindJSON(&req); err != nil { c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	email := c.Param("email")
+	productID := c.Query("product_id")
+	if productID == "" { c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: "product_id query param required"}); return }
+	existing, _ := h.repo.GetByEmailAndProduct(email, productID)
+	if existing == nil { c.JSON(http.StatusNotFound, dto.APIResponse{Success: false, Error: "student access not found"}); return }
+	existing.Active = req.Active
+	existing.InactiveReason = req.InactiveReason
+	if err := h.repo.Update(existing); err != nil { c.JSON(http.StatusInternalServerError, dto.APIResponse{Success: false, Error: err.Error()}); return }
+	c.JSON(http.StatusOK, dto.APIResponse{Success: true, Message: "Access updated"})
+}

--- a/backend/internal/models/card.go
+++ b/backend/internal/models/card.go
@@ -1,0 +1,28 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type Card struct {
+	ID           string    `gorm:"primaryKey;type:uuid" json:"id"`
+	DisciplineID string    `gorm:"not null;type:uuid" json:"discipline_id"`
+	ProductID    string    `gorm:"not null;type:uuid" json:"product_id"`
+	SubjectID    *string   `gorm:"type:uuid" json:"subject_id"`
+	Front        string    `gorm:"not null" json:"front"`
+	Back         string    `gorm:"not null" json:"back"`
+	Order        int       `gorm:"not null;default:0" json:"order"`
+	CreatedAt    time.Time `gorm:"autoCreateTime" json:"created_at"`
+}
+
+func (c *Card) BeforeCreate(tx *gorm.DB) error {
+	if c.ID == "" {
+		c.ID = uuid.New().String()
+	}
+	return nil
+}
+
+func (Card) TableName() string { return "cards" }

--- a/backend/internal/models/discipline.go
+++ b/backend/internal/models/discipline.go
@@ -1,0 +1,25 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type Discipline struct {
+	ID        string    `gorm:"primaryKey;type:uuid" json:"id"`
+	ProductID string    `gorm:"not null;type:uuid" json:"product_id"`
+	Name      string    `gorm:"not null" json:"name"`
+	Order     int       `gorm:"not null;default:0" json:"order"`
+	CreatedAt time.Time `gorm:"autoCreateTime" json:"created_at"`
+}
+
+func (d *Discipline) BeforeCreate(tx *gorm.DB) error {
+	if d.ID == "" {
+		d.ID = uuid.New().String()
+	}
+	return nil
+}
+
+func (Discipline) TableName() string { return "disciplines" }

--- a/backend/internal/models/mentor.go
+++ b/backend/internal/models/mentor.go
@@ -1,0 +1,31 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type Mentor struct {
+	ID                string    `gorm:"primaryKey;type:uuid" json:"id"`
+	Name              string    `gorm:"not null" json:"name"`
+	Email             string    `gorm:"uniqueIndex" json:"email"`
+	Slug              string    `gorm:"uniqueIndex;not null" json:"slug"`
+	LogoURL           *string   `json:"logo_url"`
+	PrimaryColor      string    `gorm:"not null;default:'#6c63ff'" json:"primary_color"`
+	SecondaryColor    string    `gorm:"not null;default:'#43e97b'" json:"secondary_color"`
+	AccentColor       *string   `gorm:"default:'#ffd166'" json:"accent_color"`
+	MentorPassword    string    `gorm:"not null" json:"-"`
+	KiwifyWebhookToken *string  `json:"-"`
+	CreatedAt         time.Time `gorm:"autoCreateTime" json:"created_at"`
+}
+
+func (m *Mentor) BeforeCreate(tx *gorm.DB) error {
+	if m.ID == "" {
+		m.ID = uuid.New().String()
+	}
+	return nil
+}
+
+func (Mentor) TableName() string { return "mentors" }

--- a/backend/internal/models/product.go
+++ b/backend/internal/models/product.go
@@ -1,0 +1,29 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type Product struct {
+	ID              string    `gorm:"primaryKey;type:uuid" json:"id"`
+	MentorID        string    `gorm:"not null;type:uuid" json:"mentor_id"`
+	Name            string    `gorm:"not null" json:"name"`
+	AccessCode      string    `gorm:"uniqueIndex;not null" json:"access_code"`
+	Active          bool      `gorm:"not null;default:true" json:"active"`
+	CoverImageURL   *string   `json:"cover_image_url"`
+	KiwifyProductID *string   `json:"kiwify_product_id"`
+	CreatedAt       time.Time `gorm:"autoCreateTime" json:"created_at"`
+	Mentor          *Mentor   `gorm:"foreignKey:MentorID" json:"mentor,omitempty"`
+}
+
+func (p *Product) BeforeCreate(tx *gorm.DB) error {
+	if p.ID == "" {
+		p.ID = uuid.New().String()
+	}
+	return nil
+}
+
+func (Product) TableName() string { return "products" }

--- a/backend/internal/models/student_access.go
+++ b/backend/internal/models/student_access.go
@@ -1,0 +1,26 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type StudentAccess struct {
+	ID             string    `gorm:"primaryKey;type:uuid" json:"id"`
+	Email          string    `gorm:"not null" json:"email"`
+	ProductID      string    `gorm:"not null;type:uuid" json:"product_id"`
+	Active         bool      `gorm:"not null;default:true" json:"active"`
+	InactiveReason *string   `json:"inactive_reason"`
+	CreatedAt      time.Time `gorm:"autoCreateTime" json:"created_at"`
+}
+
+func (s *StudentAccess) BeforeCreate(tx *gorm.DB) error {
+	if s.ID == "" {
+		s.ID = uuid.New().String()
+	}
+	return nil
+}
+
+func (StudentAccess) TableName() string { return "student_access" }

--- a/backend/internal/models/student_feedback.go
+++ b/backend/internal/models/student_feedback.go
@@ -1,0 +1,26 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type StudentFeedback struct {
+	ID              string    `gorm:"primaryKey;type:uuid" json:"id"`
+	StudentEmail    string    `gorm:"not null;column:student_email" json:"student_email"`
+	ProductID       string    `gorm:"not null;type:uuid" json:"product_id"`
+	Mensagem        string    `gorm:"not null" json:"mensagem"`
+	TotalCardsEpoca int       `gorm:"not null;default:0;column:total_cards_epoca" json:"total_cards_epoca"`
+	CriadoEm        time.Time `gorm:"not null;default:now();column:criado_em" json:"criado_em"`
+}
+
+func (s *StudentFeedback) BeforeCreate(tx *gorm.DB) error {
+	if s.ID == "" {
+		s.ID = uuid.New().String()
+	}
+	return nil
+}
+
+func (StudentFeedback) TableName() string { return "student_feedback" }

--- a/backend/internal/models/student_progress.go
+++ b/backend/internal/models/student_progress.go
@@ -1,0 +1,29 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type StudentProgress struct {
+	ID             string    `gorm:"primaryKey;type:uuid" json:"id"`
+	StudentEmail   string    `gorm:"not null" json:"student_email"`
+	CardID         string    `gorm:"not null;type:uuid" json:"card_id"`
+	ProductID      string    `gorm:"not null;type:uuid" json:"product_id"`
+	Rating         string    `gorm:"not null" json:"rating"`
+	NextReview     time.Time `gorm:"not null;default:CURRENT_DATE" json:"next_review"`
+	ReviewedAt     time.Time `gorm:"not null;default:now()" json:"reviewed_at"`
+	CorrectCount   int       `gorm:"not null;default:0" json:"correct_count"`
+	IncorrectCount int       `gorm:"not null;default:0" json:"incorrect_count"`
+}
+
+func (s *StudentProgress) BeforeCreate(tx *gorm.DB) error {
+	if s.ID == "" {
+		s.ID = uuid.New().String()
+	}
+	return nil
+}
+
+func (StudentProgress) TableName() string { return "student_progress" }

--- a/backend/internal/models/student_session.go
+++ b/backend/internal/models/student_session.go
@@ -1,0 +1,30 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type StudentSession struct {
+	ID               string    `gorm:"primaryKey;type:uuid" json:"id"`
+	StudentEmail     string    `gorm:"not null" json:"student_email"`
+	ProductID        string    `gorm:"not null;type:uuid" json:"product_id"`
+	DisciplineID     *string   `gorm:"type:uuid" json:"discipline_id"`
+	CardsReviewed    int       `gorm:"not null;default:0" json:"cards_reviewed"`
+	Correct          int       `gorm:"not null;default:0" json:"correct"`
+	Incorrect        int       `gorm:"not null;default:0" json:"incorrect"`
+	StudyTimeSeconds int       `gorm:"not null;default:0" json:"study_time_seconds"`
+	SessionDate      time.Time `gorm:"not null;default:CURRENT_DATE" json:"session_date"`
+	CreatedAt        time.Time `gorm:"autoCreateTime" json:"created_at"`
+}
+
+func (s *StudentSession) BeforeCreate(tx *gorm.DB) error {
+	if s.ID == "" {
+		s.ID = uuid.New().String()
+	}
+	return nil
+}
+
+func (StudentSession) TableName() string { return "student_sessions" }

--- a/backend/internal/repositories/card_repository.go
+++ b/backend/internal/repositories/card_repository.go
@@ -1,0 +1,59 @@
+package repositories
+
+import (
+	"errors"
+
+	"github.com/approva-cards/back-aprova-cards/internal/models"
+	"gorm.io/gorm"
+)
+
+type CardRepository interface {
+	Create(entity *models.Card) error
+	GetByID(id string) (*models.Card, error)
+	GetByDisciplineID(disciplineID string, page, pageSize int) ([]models.Card, int64, error)
+	Update(entity *models.Card) error
+	Delete(id string) error
+}
+
+type cardRepository struct{ db *gorm.DB }
+
+func NewCardRepository(db *gorm.DB) CardRepository {
+	return &cardRepository{db: db}
+}
+
+func (r *cardRepository) Create(entity *models.Card) error {
+	return r.db.Create(entity).Error
+}
+
+func (r *cardRepository) GetByID(id string) (*models.Card, error) {
+	var e models.Card
+	if err := r.db.First(&e, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.New("card not found")
+		}
+		return nil, err
+	}
+	return &e, nil
+}
+
+func (r *cardRepository) GetByDisciplineID(disciplineID string, page, pageSize int) ([]models.Card, int64, error) {
+	var entities []models.Card
+	var total int64
+	if page < 1 { page = 1 }
+	if pageSize < 1 { pageSize = 20 }
+	offset := (page - 1) * pageSize
+	q := r.db.Model(&models.Card{}).Where("discipline_id = ?", disciplineID)
+	q.Count(&total)
+	if err := q.Order(`"order" ASC`).Offset(offset).Limit(pageSize).Find(&entities).Error; err != nil {
+		return nil, 0, err
+	}
+	return entities, total, nil
+}
+
+func (r *cardRepository) Update(entity *models.Card) error {
+	return r.db.Save(entity).Error
+}
+
+func (r *cardRepository) Delete(id string) error {
+	return r.db.Delete(&models.Card{}, "id = ?", id).Error
+}

--- a/backend/internal/repositories/discipline_repository.go
+++ b/backend/internal/repositories/discipline_repository.go
@@ -1,0 +1,65 @@
+package repositories
+
+import (
+	"errors"
+
+	"github.com/approva-cards/back-aprova-cards/internal/models"
+	"gorm.io/gorm"
+)
+
+type DisciplineRepository interface {
+	Create(entity *models.Discipline) error
+	GetByID(id string) (*models.Discipline, error)
+	GetByProductID(productID string) ([]models.Discipline, error)
+	Update(entity *models.Discipline) error
+	Delete(id string) error
+	Reorder(ids []string) error
+}
+
+type disciplineRepository struct{ db *gorm.DB }
+
+func NewDisciplineRepository(db *gorm.DB) DisciplineRepository {
+	return &disciplineRepository{db: db}
+}
+
+func (r *disciplineRepository) Create(entity *models.Discipline) error {
+	return r.db.Create(entity).Error
+}
+
+func (r *disciplineRepository) GetByID(id string) (*models.Discipline, error) {
+	var e models.Discipline
+	if err := r.db.First(&e, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.New("discipline not found")
+		}
+		return nil, err
+	}
+	return &e, nil
+}
+
+func (r *disciplineRepository) GetByProductID(productID string) ([]models.Discipline, error) {
+	var entities []models.Discipline
+	if err := r.db.Where("product_id = ?", productID).Order(`"order" ASC`).Find(&entities).Error; err != nil {
+		return nil, err
+	}
+	return entities, nil
+}
+
+func (r *disciplineRepository) Update(entity *models.Discipline) error {
+	return r.db.Save(entity).Error
+}
+
+func (r *disciplineRepository) Delete(id string) error {
+	return r.db.Delete(&models.Discipline{}, "id = ?", id).Error
+}
+
+func (r *disciplineRepository) Reorder(ids []string) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		for i, id := range ids {
+			if err := tx.Model(&models.Discipline{}).Where("id = ?", id).Update("order", i).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/backend/internal/repositories/feedback_repository.go
+++ b/backend/internal/repositories/feedback_repository.go
@@ -1,0 +1,35 @@
+package repositories
+
+import (
+	"github.com/approva-cards/back-aprova-cards/internal/models"
+	"gorm.io/gorm"
+)
+
+type FeedbackRepository interface {
+	Create(entity *models.StudentFeedback) error
+	GetByProductID(productID string, page, pageSize int) ([]models.StudentFeedback, int64, error)
+}
+
+type feedbackRepository struct{ db *gorm.DB }
+
+func NewFeedbackRepository(db *gorm.DB) FeedbackRepository {
+	return &feedbackRepository{db: db}
+}
+
+func (r *feedbackRepository) Create(entity *models.StudentFeedback) error {
+	return r.db.Create(entity).Error
+}
+
+func (r *feedbackRepository) GetByProductID(productID string, page, pageSize int) ([]models.StudentFeedback, int64, error) {
+	var entities []models.StudentFeedback
+	var total int64
+	if page < 1 { page = 1 }
+	if pageSize < 1 { pageSize = 20 }
+	offset := (page - 1) * pageSize
+	q := r.db.Model(&models.StudentFeedback{}).Where("product_id = ?", productID)
+	q.Count(&total)
+	if err := q.Order("criado_em DESC").Offset(offset).Limit(pageSize).Find(&entities).Error; err != nil {
+		return nil, 0, err
+	}
+	return entities, total, nil
+}

--- a/backend/internal/repositories/mentor_repository.go
+++ b/backend/internal/repositories/mentor_repository.go
@@ -1,0 +1,84 @@
+package repositories
+
+import (
+	"errors"
+
+	"github.com/approva-cards/back-aprova-cards/internal/models"
+	"gorm.io/gorm"
+)
+
+type MentorRepository interface {
+	Create(entity *models.Mentor) error
+	GetByID(id string) (*models.Mentor, error)
+	GetByEmail(email string) (*models.Mentor, error)
+	GetBySlug(slug string) (*models.Mentor, error)
+	GetAll(page, pageSize int) ([]models.Mentor, int64, error)
+	Update(entity *models.Mentor) error
+	Delete(id string) error
+}
+
+type mentorRepository struct{ db *gorm.DB }
+
+func NewMentorRepository(db *gorm.DB) MentorRepository {
+	return &mentorRepository{db: db}
+}
+
+func (r *mentorRepository) Create(entity *models.Mentor) error {
+	return r.db.Create(entity).Error
+}
+
+func (r *mentorRepository) GetByID(id string) (*models.Mentor, error) {
+	var e models.Mentor
+	if err := r.db.First(&e, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.New("mentor not found")
+		}
+		return nil, err
+	}
+	return &e, nil
+}
+
+func (r *mentorRepository) GetByEmail(email string) (*models.Mentor, error) {
+	var e models.Mentor
+	if err := r.db.First(&e, "email = ?", email).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &e, nil
+}
+
+func (r *mentorRepository) GetBySlug(slug string) (*models.Mentor, error) {
+	var e models.Mentor
+	if err := r.db.First(&e, "slug = ?", slug).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &e, nil
+}
+
+func (r *mentorRepository) GetAll(page, pageSize int) ([]models.Mentor, int64, error) {
+	var entities []models.Mentor
+	var total int64
+	if page < 1 { page = 1 }
+	if pageSize < 1 { pageSize = 10 }
+	offset := (page - 1) * pageSize
+	if err := r.db.Model(&models.Mentor{}).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	if err := r.db.Order("created_at DESC").Offset(offset).Limit(pageSize).Find(&entities).Error; err != nil {
+		return nil, 0, err
+	}
+	return entities, total, nil
+}
+
+func (r *mentorRepository) Update(entity *models.Mentor) error {
+	return r.db.Save(entity).Error
+}
+
+func (r *mentorRepository) Delete(id string) error {
+	return r.db.Delete(&models.Mentor{}, "id = ?", id).Error
+}

--- a/backend/internal/repositories/product_repository.go
+++ b/backend/internal/repositories/product_repository.go
@@ -1,0 +1,73 @@
+package repositories
+
+import (
+	"errors"
+
+	"github.com/approva-cards/back-aprova-cards/internal/models"
+	"gorm.io/gorm"
+)
+
+type ProductRepository interface {
+	Create(entity *models.Product) error
+	GetByID(id string) (*models.Product, error)
+	GetByMentorID(mentorID string, page, pageSize int) ([]models.Product, int64, error)
+	GetAll(page, pageSize int) ([]models.Product, int64, error)
+	Update(entity *models.Product) error
+	Delete(id string) error
+}
+
+type productRepository struct{ db *gorm.DB }
+
+func NewProductRepository(db *gorm.DB) ProductRepository {
+	return &productRepository{db: db}
+}
+
+func (r *productRepository) Create(entity *models.Product) error {
+	return r.db.Create(entity).Error
+}
+
+func (r *productRepository) GetByID(id string) (*models.Product, error) {
+	var e models.Product
+	if err := r.db.First(&e, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.New("product not found")
+		}
+		return nil, err
+	}
+	return &e, nil
+}
+
+func (r *productRepository) GetByMentorID(mentorID string, page, pageSize int) ([]models.Product, int64, error) {
+	var entities []models.Product
+	var total int64
+	if page < 1 { page = 1 }
+	if pageSize < 1 { pageSize = 10 }
+	offset := (page - 1) * pageSize
+	q := r.db.Model(&models.Product{}).Where("mentor_id = ?", mentorID)
+	q.Count(&total)
+	if err := q.Order("created_at DESC").Offset(offset).Limit(pageSize).Find(&entities).Error; err != nil {
+		return nil, 0, err
+	}
+	return entities, total, nil
+}
+
+func (r *productRepository) GetAll(page, pageSize int) ([]models.Product, int64, error) {
+	var entities []models.Product
+	var total int64
+	if page < 1 { page = 1 }
+	if pageSize < 1 { pageSize = 10 }
+	offset := (page - 1) * pageSize
+	r.db.Model(&models.Product{}).Count(&total)
+	if err := r.db.Order("created_at DESC").Offset(offset).Limit(pageSize).Find(&entities).Error; err != nil {
+		return nil, 0, err
+	}
+	return entities, total, nil
+}
+
+func (r *productRepository) Update(entity *models.Product) error {
+	return r.db.Save(entity).Error
+}
+
+func (r *productRepository) Delete(id string) error {
+	return r.db.Delete(&models.Product{}, "id = ?", id).Error
+}

--- a/backend/internal/repositories/student_access_repository.go
+++ b/backend/internal/repositories/student_access_repository.go
@@ -1,0 +1,54 @@
+package repositories
+
+import (
+	"errors"
+
+	"github.com/approva-cards/back-aprova-cards/internal/models"
+	"gorm.io/gorm"
+)
+
+type StudentAccessRepository interface {
+	Create(entity *models.StudentAccess) error
+	GetByProductID(productID string, page, pageSize int) ([]models.StudentAccess, int64, error)
+	GetByEmailAndProduct(email, productID string) (*models.StudentAccess, error)
+	Update(entity *models.StudentAccess) error
+}
+
+type studentAccessRepository struct{ db *gorm.DB }
+
+func NewStudentAccessRepository(db *gorm.DB) StudentAccessRepository {
+	return &studentAccessRepository{db: db}
+}
+
+func (r *studentAccessRepository) Create(entity *models.StudentAccess) error {
+	return r.db.Create(entity).Error
+}
+
+func (r *studentAccessRepository) GetByProductID(productID string, page, pageSize int) ([]models.StudentAccess, int64, error) {
+	var entities []models.StudentAccess
+	var total int64
+	if page < 1 { page = 1 }
+	if pageSize < 1 { pageSize = 20 }
+	offset := (page - 1) * pageSize
+	q := r.db.Model(&models.StudentAccess{}).Where("product_id = ?", productID)
+	q.Count(&total)
+	if err := q.Order("created_at DESC").Offset(offset).Limit(pageSize).Find(&entities).Error; err != nil {
+		return nil, 0, err
+	}
+	return entities, total, nil
+}
+
+func (r *studentAccessRepository) GetByEmailAndProduct(email, productID string) (*models.StudentAccess, error) {
+	var e models.StudentAccess
+	if err := r.db.First(&e, "email = ? AND product_id = ?", email, productID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &e, nil
+}
+
+func (r *studentAccessRepository) Update(entity *models.StudentAccess) error {
+	return r.db.Save(entity).Error
+}

--- a/backend/internal/usecases/auth_usecase.go
+++ b/backend/internal/usecases/auth_usecase.go
@@ -1,0 +1,59 @@
+package usecases
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+
+	"github.com/approva-cards/back-aprova-cards/internal/dto"
+	"github.com/approva-cards/back-aprova-cards/internal/repositories"
+	"github.com/approva-cards/back-aprova-cards/pkg/auth"
+)
+
+type AuthUseCase interface {
+	AdminLogin(req *dto.AdminLoginRequest, jwtSecret string, jwtExp int) (*dto.LoginResponse, error)
+}
+
+type authUseCase struct {
+	mentorRepo repositories.MentorRepository
+	adminEmail string
+	adminPassHash string
+}
+
+func NewAuthUseCase(mentorRepo repositories.MentorRepository, adminEmail, adminPass string) AuthUseCase {
+	h := sha256.Sum256([]byte(adminPass))
+	return &authUseCase{
+		mentorRepo:    mentorRepo,
+		adminEmail:    adminEmail,
+		adminPassHash: hex.EncodeToString(h[:]),
+	}
+}
+
+func (uc *authUseCase) AdminLogin(req *dto.AdminLoginRequest, jwtSecret string, jwtExp int) (*dto.LoginResponse, error) {
+	if req.Email != uc.adminEmail {
+		return nil, errors.New("invalid credentials")
+	}
+
+	h := sha256.Sum256([]byte(req.Password))
+	inputHash := hex.EncodeToString(h[:])
+
+	if subtle.ConstantTimeCompare([]byte(inputHash), []byte(uc.adminPassHash)) != 1 {
+		return nil, errors.New("invalid credentials")
+	}
+
+	token, err := auth.GenerateToken(jwtSecret, jwtExp, "admin", uc.adminEmail, "admin")
+	if err != nil {
+		return nil, errors.New("failed to generate token")
+	}
+
+	return &dto.LoginResponse{
+		Token: token,
+		User: dto.UserInfo{
+			ID:    "admin",
+			Email: uc.adminEmail,
+			Role:  "admin",
+			Name:  "Administrator",
+		},
+	}, nil
+}

--- a/backend/internal/usecases/card_usecase.go
+++ b/backend/internal/usecases/card_usecase.go
@@ -1,0 +1,66 @@
+package usecases
+
+import (
+	"errors"
+
+	"github.com/approva-cards/back-aprova-cards/internal/dto"
+	"github.com/approva-cards/back-aprova-cards/internal/models"
+	"github.com/approva-cards/back-aprova-cards/internal/repositories"
+)
+
+type CardUseCase interface {
+	Create(req *dto.CreateCardRequest, productID string) (*dto.CardResponse, error)
+	GetByDisciplineID(disciplineID string, page, pageSize int) (*dto.PaginatedResponse, error)
+	Update(id string, req *dto.UpdateCardRequest) (*dto.CardResponse, error)
+	Delete(id string) error
+}
+
+type cardUseCase struct {
+	repo     repositories.CardRepository
+	discRepo repositories.DisciplineRepository
+}
+
+func NewCardUseCase(repo repositories.CardRepository, discRepo repositories.DisciplineRepository) CardUseCase {
+	return &cardUseCase{repo: repo, discRepo: discRepo}
+}
+
+func (uc *cardUseCase) Create(req *dto.CreateCardRequest, productID string) (*dto.CardResponse, error) {
+	if len(req.Front) == 0 {
+		return nil, errors.New("front cannot be empty")
+	}
+	disc, err := uc.discRepo.GetByID(req.DisciplineID)
+	if err != nil { return nil, errors.New("discipline not found") }
+
+	pid := productID
+	if pid == "" { pid = disc.ProductID }
+
+	e := &models.Card{DisciplineID: req.DisciplineID, ProductID: pid, Front: req.Front, Back: req.Back, Order: req.Order}
+	if err := uc.repo.Create(e); err != nil { return nil, err }
+	return cardToDTO(e), nil
+}
+
+func (uc *cardUseCase) GetByDisciplineID(disciplineID string, page, pageSize int) (*dto.PaginatedResponse, error) {
+	entities, total, err := uc.repo.GetByDisciplineID(disciplineID, page, pageSize)
+	if err != nil { return nil, err }
+	if pageSize < 1 { pageSize = 20 }
+	var r []dto.CardResponse
+	for _, e := range entities { r = append(r, *cardToDTO(&e)) }
+	tp := int(total) / pageSize; if int(total)%pageSize > 0 { tp++ }
+	return &dto.PaginatedResponse{Data: r, Total: total, Page: page, PageSize: pageSize, TotalPages: tp}, nil
+}
+
+func (uc *cardUseCase) Update(id string, req *dto.UpdateCardRequest) (*dto.CardResponse, error) {
+	e, err := uc.repo.GetByID(id)
+	if err != nil { return nil, err }
+	if req.Front != "" { e.Front = req.Front }
+	if req.Back != "" { e.Back = req.Back }
+	if req.Order != nil { e.Order = *req.Order }
+	if err := uc.repo.Update(e); err != nil { return nil, err }
+	return cardToDTO(e), nil
+}
+
+func (uc *cardUseCase) Delete(id string) error { return uc.repo.Delete(id) }
+
+func cardToDTO(e *models.Card) *dto.CardResponse {
+	return &dto.CardResponse{ID: e.ID, DisciplineID: e.DisciplineID, ProductID: e.ProductID, Front: e.Front, Back: e.Back, Order: e.Order, CreatedAt: e.CreatedAt.Format("2006-01-02T15:04:05Z")}
+}

--- a/backend/internal/usecases/discipline_usecase.go
+++ b/backend/internal/usecases/discipline_usecase.go
@@ -1,0 +1,61 @@
+package usecases
+
+import (
+	"github.com/approva-cards/back-aprova-cards/internal/dto"
+	"github.com/approva-cards/back-aprova-cards/internal/models"
+	"github.com/approva-cards/back-aprova-cards/internal/repositories"
+)
+
+type DisciplineUseCase interface {
+	Create(req *dto.CreateDisciplineRequest) (*dto.DisciplineResponse, error)
+	GetByProductID(productID string) ([]dto.DisciplineResponse, error)
+	Update(id string, req *dto.UpdateDisciplineRequest) (*dto.DisciplineResponse, error)
+	Delete(id string) error
+	Reorder(id string, req *dto.ReorderDisciplinesRequest) ([]dto.DisciplineResponse, error)
+}
+
+type disciplineUseCase struct{ repo repositories.DisciplineRepository }
+
+func NewDisciplineUseCase(repo repositories.DisciplineRepository) DisciplineUseCase {
+	return &disciplineUseCase{repo: repo}
+}
+
+func (uc *disciplineUseCase) Create(req *dto.CreateDisciplineRequest) (*dto.DisciplineResponse, error) {
+	e := &models.Discipline{ProductID: req.ProductID, Name: req.Name, Order: req.Order}
+	if err := uc.repo.Create(e); err != nil { return nil, err }
+	return disciplineToDTO(e), nil
+}
+
+func (uc *disciplineUseCase) GetByProductID(productID string) ([]dto.DisciplineResponse, error) {
+	entities, err := uc.repo.GetByProductID(productID)
+	if err != nil { return nil, err }
+	var r []dto.DisciplineResponse
+	for _, e := range entities { r = append(r, *disciplineToDTO(&e)) }
+	return r, nil
+}
+
+func (uc *disciplineUseCase) Update(id string, req *dto.UpdateDisciplineRequest) (*dto.DisciplineResponse, error) {
+	e, err := uc.repo.GetByID(id)
+	if err != nil { return nil, err }
+	if req.Name != "" { e.Name = req.Name }
+	if req.Order != nil { e.Order = *req.Order }
+	if err := uc.repo.Update(e); err != nil { return nil, err }
+	return disciplineToDTO(e), nil
+}
+
+func (uc *disciplineUseCase) Delete(id string) error { return uc.repo.Delete(id) }
+
+func (uc *disciplineUseCase) Reorder(_ string, req *dto.ReorderDisciplinesRequest) ([]dto.DisciplineResponse, error) {
+	if err := uc.repo.Reorder(req.IDs); err != nil { return nil, err }
+	if len(req.IDs) > 0 {
+		first, _ := uc.repo.GetByID(req.IDs[0])
+		if first != nil {
+			return uc.GetByProductID(first.ProductID)
+		}
+	}
+	return nil, nil
+}
+
+func disciplineToDTO(e *models.Discipline) *dto.DisciplineResponse {
+	return &dto.DisciplineResponse{ID: e.ID, ProductID: e.ProductID, Name: e.Name, Order: e.Order, CreatedAt: e.CreatedAt.Format("2006-01-02T15:04:05Z")}
+}

--- a/backend/internal/usecases/mentor_usecase.go
+++ b/backend/internal/usecases/mentor_usecase.go
@@ -1,0 +1,99 @@
+package usecases
+
+import (
+	"errors"
+
+	"github.com/approva-cards/back-aprova-cards/internal/dto"
+	"github.com/approva-cards/back-aprova-cards/internal/models"
+	"github.com/approva-cards/back-aprova-cards/internal/repositories"
+)
+
+type MentorUseCase interface {
+	Create(req *dto.CreateMentorRequest) (*dto.MentorResponse, error)
+	GetByID(id string) (*dto.MentorResponse, error)
+	GetAll(page, pageSize int) (*dto.PaginatedResponse, error)
+	Update(id string, req *dto.UpdateMentorRequest) (*dto.MentorResponse, error)
+	Delete(id string) error
+}
+
+type mentorUseCase struct {
+	repo repositories.MentorRepository
+}
+
+func NewMentorUseCase(repo repositories.MentorRepository) MentorUseCase {
+	return &mentorUseCase{repo: repo}
+}
+
+func (uc *mentorUseCase) Create(req *dto.CreateMentorRequest) (*dto.MentorResponse, error) {
+	existing, _ := uc.repo.GetByEmail(req.Email)
+	if existing != nil {
+		return nil, errors.New("email already exists")
+	}
+	existingSlug, _ := uc.repo.GetBySlug(req.Slug)
+	if existingSlug != nil {
+		return nil, errors.New("slug already exists")
+	}
+
+	entity := &models.Mentor{
+		Name:           req.Name,
+		Email:          req.Email,
+		Slug:           req.Slug,
+		MentorPassword: req.MentorPassword,
+		PrimaryColor:   req.PrimaryColor,
+		SecondaryColor: req.SecondaryColor,
+		LogoURL:        req.LogoURL,
+	}
+	if entity.PrimaryColor == "" { entity.PrimaryColor = "#6c63ff" }
+	if entity.SecondaryColor == "" { entity.SecondaryColor = "#43e97b" }
+
+	if err := uc.repo.Create(entity); err != nil {
+		return nil, err
+	}
+	return mentorToDTO(entity), nil
+}
+
+func (uc *mentorUseCase) GetByID(id string) (*dto.MentorResponse, error) {
+	entity, err := uc.repo.GetByID(id)
+	if err != nil { return nil, err }
+	return mentorToDTO(entity), nil
+}
+
+func (uc *mentorUseCase) GetAll(page, pageSize int) (*dto.PaginatedResponse, error) {
+	entities, total, err := uc.repo.GetAll(page, pageSize)
+	if err != nil { return nil, err }
+	if pageSize < 1 { pageSize = 10 }
+	var responses []dto.MentorResponse
+	for _, e := range entities {
+		responses = append(responses, *mentorToDTO(&e))
+	}
+	totalPages := int(total) / pageSize
+	if int(total)%pageSize > 0 { totalPages++ }
+	return &dto.PaginatedResponse{Data: responses, Total: total, Page: page, PageSize: pageSize, TotalPages: totalPages}, nil
+}
+
+func (uc *mentorUseCase) Update(id string, req *dto.UpdateMentorRequest) (*dto.MentorResponse, error) {
+	entity, err := uc.repo.GetByID(id)
+	if err != nil { return nil, err }
+	if req.Name != "" { entity.Name = req.Name }
+	if req.Email != "" { entity.Email = req.Email }
+	if req.Slug != "" { entity.Slug = req.Slug }
+	if req.MentorPassword != "" { entity.MentorPassword = req.MentorPassword }
+	if req.PrimaryColor != "" { entity.PrimaryColor = req.PrimaryColor }
+	if req.SecondaryColor != "" { entity.SecondaryColor = req.SecondaryColor }
+	if req.LogoURL != nil { entity.LogoURL = req.LogoURL }
+	if err := uc.repo.Update(entity); err != nil { return nil, err }
+	return mentorToDTO(entity), nil
+}
+
+func (uc *mentorUseCase) Delete(id string) error {
+	return uc.repo.Delete(id)
+}
+
+func mentorToDTO(e *models.Mentor) *dto.MentorResponse {
+	return &dto.MentorResponse{
+		ID: e.ID, Name: e.Name, Email: e.Email, Slug: e.Slug,
+		LogoURL: e.LogoURL, PrimaryColor: e.PrimaryColor,
+		SecondaryColor: e.SecondaryColor, AccentColor: e.AccentColor,
+		CreatedAt: e.CreatedAt.Format("2006-01-02T15:04:05Z"),
+	}
+}

--- a/backend/internal/usecases/product_usecase.go
+++ b/backend/internal/usecases/product_usecase.go
@@ -1,0 +1,71 @@
+package usecases
+
+import (
+	"github.com/approva-cards/back-aprova-cards/internal/dto"
+	"github.com/approva-cards/back-aprova-cards/internal/models"
+	"github.com/approva-cards/back-aprova-cards/internal/repositories"
+)
+
+type ProductUseCase interface {
+	Create(req *dto.CreateProductRequest) (*dto.ProductResponse, error)
+	GetByID(id string) (*dto.ProductResponse, error)
+	GetAll(page, pageSize int) (*dto.PaginatedResponse, error)
+	GetByMentorID(mentorID string, page, pageSize int) (*dto.PaginatedResponse, error)
+	Update(id string, req *dto.UpdateProductRequest) (*dto.ProductResponse, error)
+	Delete(id string) error
+}
+
+type productUseCase struct{ repo repositories.ProductRepository }
+
+func NewProductUseCase(repo repositories.ProductRepository) ProductUseCase {
+	return &productUseCase{repo: repo}
+}
+
+func (uc *productUseCase) Create(req *dto.CreateProductRequest) (*dto.ProductResponse, error) {
+	entity := &models.Product{MentorID: req.MentorID, Name: req.Name, AccessCode: req.AccessCode, Active: true, CoverImageURL: req.CoverImageURL}
+	if err := uc.repo.Create(entity); err != nil { return nil, err }
+	return productToDTO(entity), nil
+}
+
+func (uc *productUseCase) GetByID(id string) (*dto.ProductResponse, error) {
+	e, err := uc.repo.GetByID(id)
+	if err != nil { return nil, err }
+	return productToDTO(e), nil
+}
+
+func (uc *productUseCase) GetAll(page, pageSize int) (*dto.PaginatedResponse, error) {
+	entities, total, err := uc.repo.GetAll(page, pageSize)
+	if err != nil { return nil, err }
+	if pageSize < 1 { pageSize = 10 }
+	var r []dto.ProductResponse
+	for _, e := range entities { r = append(r, *productToDTO(&e)) }
+	tp := int(total) / pageSize; if int(total)%pageSize > 0 { tp++ }
+	return &dto.PaginatedResponse{Data: r, Total: total, Page: page, PageSize: pageSize, TotalPages: tp}, nil
+}
+
+func (uc *productUseCase) GetByMentorID(mentorID string, page, pageSize int) (*dto.PaginatedResponse, error) {
+	entities, total, err := uc.repo.GetByMentorID(mentorID, page, pageSize)
+	if err != nil { return nil, err }
+	if pageSize < 1 { pageSize = 10 }
+	var r []dto.ProductResponse
+	for _, e := range entities { r = append(r, *productToDTO(&e)) }
+	tp := int(total) / pageSize; if int(total)%pageSize > 0 { tp++ }
+	return &dto.PaginatedResponse{Data: r, Total: total, Page: page, PageSize: pageSize, TotalPages: tp}, nil
+}
+
+func (uc *productUseCase) Update(id string, req *dto.UpdateProductRequest) (*dto.ProductResponse, error) {
+	e, err := uc.repo.GetByID(id)
+	if err != nil { return nil, err }
+	if req.Name != "" { e.Name = req.Name }
+	if req.AccessCode != "" { e.AccessCode = req.AccessCode }
+	if req.Active != nil { e.Active = *req.Active }
+	if req.CoverImageURL != nil { e.CoverImageURL = req.CoverImageURL }
+	if err := uc.repo.Update(e); err != nil { return nil, err }
+	return productToDTO(e), nil
+}
+
+func (uc *productUseCase) Delete(id string) error { return uc.repo.Delete(id) }
+
+func productToDTO(e *models.Product) *dto.ProductResponse {
+	return &dto.ProductResponse{ID: e.ID, MentorID: e.MentorID, Name: e.Name, AccessCode: e.AccessCode, Active: e.Active, CoverImageURL: e.CoverImageURL, CreatedAt: e.CreatedAt.Format("2006-01-02T15:04:05Z")}
+}

--- a/backend/pkg/auth/jwt.go
+++ b/backend/pkg/auth/jwt.go
@@ -1,0 +1,97 @@
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+)
+
+var (
+	ErrInvalidToken = errors.New("invalid token")
+	ErrExpiredToken = errors.New("token expired")
+)
+
+type Claims struct {
+	Sub   string `json:"sub"`
+	Email string `json:"email"`
+	Role  string `json:"role"`
+	Exp   int64  `json:"exp"`
+	Iat   int64  `json:"iat"`
+}
+
+func GenerateToken(secret string, expSeconds int, userID, email, role string) (string, error) {
+	now := time.Now().UTC()
+	claims := Claims{
+		Sub:   userID,
+		Email: email,
+		Role:  role,
+		Iat:   now.Unix(),
+		Exp:   now.Add(time.Duration(expSeconds) * time.Second).Unix(),
+	}
+
+	header := base64Encode([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+	payloadB64 := base64Encode(payload)
+
+	sigInput := header + "." + payloadB64
+	sig := sign(sigInput, secret)
+
+	return sigInput + "." + sig, nil
+}
+
+func ValidateToken(secret, tokenStr string) (*Claims, error) {
+	parts := strings.Split(tokenStr, ".")
+	if len(parts) != 3 {
+		return nil, ErrInvalidToken
+	}
+
+	sigInput := parts[0] + "." + parts[1]
+	expectedSig := sign(sigInput, secret)
+
+	if !hmac.Equal([]byte(parts[2]), []byte(expectedSig)) {
+		return nil, ErrInvalidToken
+	}
+
+	payloadBytes, err := base64Decode(parts[1])
+	if err != nil {
+		return nil, ErrInvalidToken
+	}
+
+	var claims Claims
+	if err := json.Unmarshal(payloadBytes, &claims); err != nil {
+		return nil, ErrInvalidToken
+	}
+
+	if time.Now().UTC().Unix() > claims.Exp {
+		return nil, ErrExpiredToken
+	}
+
+	return &claims, nil
+}
+
+func sign(input, secret string) string {
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write([]byte(input))
+	return base64Encode(h.Sum(nil))
+}
+
+func base64Encode(data []byte) string {
+	return strings.TrimRight(base64.URLEncoding.EncodeToString(data), "=")
+}
+
+func base64Decode(s string) ([]byte, error) {
+	switch len(s) % 4 {
+	case 2:
+		s += "=="
+	case 3:
+		s += "="
+	}
+	return base64.URLEncoding.DecodeString(s)
+}

--- a/backend/pkg/middleware/auth_middleware.go
+++ b/backend/pkg/middleware/auth_middleware.go
@@ -1,0 +1,86 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/approva-cards/back-aprova-cards/pkg/auth"
+	"github.com/gin-gonic/gin"
+)
+
+func AuthMiddleware(jwtSecret string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		header := c.GetHeader("Authorization")
+		if header == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"success": false,
+				"error":   "missing authorization header",
+			})
+			return
+		}
+
+		parts := strings.SplitN(header, " ", 2)
+		if len(parts) != 2 || !strings.EqualFold(parts[0], "bearer") {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"success": false,
+				"error":   "invalid authorization format, use: Bearer <token>",
+			})
+			return
+		}
+
+		claims, err := auth.ValidateToken(jwtSecret, parts[1])
+		if err != nil {
+			status := http.StatusUnauthorized
+			msg := "invalid token"
+			if err == auth.ErrExpiredToken {
+				msg = "token expired"
+			}
+			c.AbortWithStatusJSON(status, gin.H{
+				"success": false,
+				"error":   msg,
+			})
+			return
+		}
+
+		c.Set("user_id", claims.Sub)
+		c.Set("user_email", claims.Email)
+		c.Set("user_role", claims.Role)
+		c.Next()
+	}
+}
+
+func AdminOnly() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		role, exists := c.Get("user_role")
+		if !exists || role != "admin" {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+				"success": false,
+				"error":   "admin access required",
+			})
+			return
+		}
+		c.Next()
+	}
+}
+
+func MentorOrAdmin() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		role, exists := c.Get("user_role")
+		if !exists {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+				"success": false,
+				"error":   "authentication required",
+			})
+			return
+		}
+		r := role.(string)
+		if r != "admin" && r != "mentor" {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+				"success": false,
+				"error":   "mentor or admin access required",
+			})
+			return
+		}
+		c.Next()
+	}
+}

--- a/backend/pkg/middleware/middleware.go
+++ b/backend/pkg/middleware/middleware.go
@@ -58,10 +58,3 @@ func CORSMiddleware(allowedOrigins string) gin.HandlerFunc {
 	}
 }
 
-// RateLimitMiddleware simples (melhore com redis em produção)
-func RateLimitMiddleware() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		// TODO: Implementar rate limit com redis
-		c.Next()
-	}
-}

--- a/backend/pkg/middleware/rate_limit.go
+++ b/backend/pkg/middleware/rate_limit.go
@@ -1,0 +1,76 @@
+package middleware
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type rateLimitEntry struct {
+	count    int
+	windowStart time.Time
+}
+
+type RateLimiter struct {
+	mu       sync.RWMutex
+	entries  map[string]*rateLimitEntry
+	limit    int
+	window   time.Duration
+}
+
+func NewRateLimiter(limit int, windowSeconds int) *RateLimiter {
+	rl := &RateLimiter{
+		entries: make(map[string]*rateLimitEntry),
+		limit:   limit,
+		window:  time.Duration(windowSeconds) * time.Second,
+	}
+	go rl.cleanup()
+	return rl
+}
+
+func (rl *RateLimiter) cleanup() {
+	ticker := time.NewTicker(rl.window)
+	defer ticker.Stop()
+	for range ticker.C {
+		rl.mu.Lock()
+		now := time.Now()
+		for key, entry := range rl.entries {
+			if now.Sub(entry.windowStart) > rl.window {
+				delete(rl.entries, key)
+			}
+		}
+		rl.mu.Unlock()
+	}
+}
+
+func (rl *RateLimiter) Allow(key string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	entry, exists := rl.entries[key]
+
+	if !exists || now.Sub(entry.windowStart) > rl.window {
+		rl.entries[key] = &rateLimitEntry{count: 1, windowStart: now}
+		return true
+	}
+
+	entry.count++
+	return entry.count <= rl.limit
+}
+
+func RateLimitByIP(limiter *RateLimiter) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ip := c.ClientIP()
+		if !limiter.Allow(ip) {
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+				"success": false,
+				"error":   "rate limit exceeded, try again later",
+			})
+			return
+		}
+		c.Next()
+	}
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -110,6 +110,7 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -125,6 +126,7 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3357,7 +3359,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3476,7 +3479,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3488,7 +3490,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3547,7 +3548,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -3928,7 +3928,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4006,6 +4005,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4209,7 +4209,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4668,7 +4667,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -4765,7 +4763,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -4817,8 +4816,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -5001,7 +4999,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5758,7 +5755,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5788,7 +5784,6 @@
       "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "abab": "^2.0.6",
         "acorn": "^8.8.1",
@@ -5976,6 +5971,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6372,7 +6368,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6540,6 +6535,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6555,6 +6551,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6640,7 +6637,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6667,7 +6663,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6681,7 +6676,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
       "integrity": "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -6698,7 +6692,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -7303,7 +7298,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -7437,7 +7431,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7560,7 +7553,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7760,7 +7752,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",


### PR DESCRIPTION
- [AUTH] POST /api/v1/auth/admin-login com rate limit 5/5min
- [AUTH] Middleware JWT para rotas protegidas (/health público)
- [MENTORS] CRUD completo (admin only)
- [PRODUCTS] CRUD completo com filtro por mentor
- [DISCIPLINES] CRUD + reorder
- [CARDS] CRUD com paginação
- [STUDENTS] GET/POST/PATCH acesso por produto
- [FEEDBACK] POST + GET por produto
- [INFRA] Rate limiting real in-memory por IP
- [INFRA] JWT zero-dependency (pkg/auth)
- Models mapeados para schema Supabase existente