### PR TITLE
feat: autenticação e provisionamento de mentores via Supabase Auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,38 +1,49 @@
 # ============================================================
 # Aprova Cards - Environment Variables
-# Copy this file to .env and fill in your values
+# Copy to .env and fill your values
+#
+# Current architecture:
+# - Auth/session is handled by Supabase (frontend TS via supabase-js)
+# - API/business logic is handled by backend Go
+# - Supabase Edge Functions are NOT required for the main app flow
 # ============================================================
 
-# ----- Server -----
+# ----- Backend: Server -----
 SERVER_PORT=8080
 SERVER_ENV=development   # development | staging | production
 
-# ----- Database (Supabase PostgreSQL) -----
+# ----- Backend: Database (Supabase Postgres) -----
 DB_HOST=db.xxxxxxxxxxxx.supabase.co
 DB_PORT=5432
 DB_USER=postgres
 DB_PASSWORD=your-db-password
 DB_NAME=postgres
-DB_SSL_MODE=require      # require for Supabase, disable for local
+DB_SSL_MODE=require      # require for Supabase, disable only on local DB
 
+# ----- Backend: Supabase Admin API (required for provisioning mentor auth users) -----
+SUPABASE_URL=https://xxxxxxxxxxxx.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
-# ----- Admin -----
-ADMIN_EMAIL=admin@aprovacards.com
-ADMIN_PASSWORD=change-this-password
-
-# ----- JWT -----
+# ----- Backend: JWT (Go API token/signature config) -----
 JWT_SECRET=generate-a-strong-secret-here
 JWT_EXPIRATION=3600
 
-# ----- CORS -----
+# ----- Backend: CORS -----
 CORS_ALLOWED_ORIGINS=http://localhost:5173
 
-# ----- Rate Limit -----
+# ----- Backend: Rate Limit -----
 RATE_LIMIT_ENABLED=true
 RATE_LIMIT_REQUESTS=100
 RATE_LIMIT_WINDOW_SECONDS=60
 
+# ----- Optional: Legacy admin check (only if still used in backend/flow) -----
+ADMIN_EMAIL=admin@aprovacards.com
+ADMIN_PASSWORD=change-this-password
+
 # ----- Frontend (Vite) -----
+# Required for Supabase auth/client on frontend
 VITE_SUPABASE_URL=https://xxxxxxxxxxxx.supabase.co
 VITE_SUPABASE_PUBLISHABLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+
+# Optional: explicit backend API base (useful for services outside Vite proxy)
 VITE_API_BASE_URL=http://localhost:8080/api/v1

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/approva-cards/back-aprova-cards/internal/handlers"
 	"github.com/approva-cards/back-aprova-cards/internal/repositories"
 	"github.com/approva-cards/back-aprova-cards/internal/usecases"
+	appauth "github.com/approva-cards/back-aprova-cards/pkg/auth"
 	"github.com/approva-cards/back-aprova-cards/pkg/middleware"
 	"github.com/gin-gonic/gin"
 	"gorm.io/driver/postgres"
@@ -66,6 +67,12 @@ func connectDatabase(cfg *config.Config) *gorm.DB {
 
 func setupRoutes(engine *gin.Engine, db *gorm.DB, cfg *config.Config) {
 	api := engine.Group("/api/v1")
+	supabaseAdminClient := appauth.NewSupabaseAdminClient(cfg.Supabase.URL, cfg.Supabase.ServiceRoleKey)
+	if supabaseAdminClient.IsConfigured() {
+		fmt.Println("✅ Mentor provisioning: Supabase Admin configured")
+	} else {
+		fmt.Printf("⚠️ Mentor provisioning disabled: %s\n", supabaseAdminClient.ConfigDiagnostic())
+	}
 
 	// ---- Health (public) ----
 	healthHandler := handlers.NewHealthHandler(db)
@@ -76,12 +83,14 @@ func setupRoutes(engine *gin.Engine, db *gorm.DB, cfg *config.Config) {
 	mentorRepo := repositories.NewMentorRepository(db)
 	authUC := usecases.NewAuthUseCase(mentorRepo, cfg.Admin.Email, cfg.Admin.Password)
 	authHandler := handlers.NewAuthHandler(authUC, cfg.JWT.Secret, cfg.JWT.Expiration)
+	adminMentorUC := usecases.NewAdminMentorUseCase(db, supabaseAdminClient)
 
 	authGroup := api.Group("/auth")
 	authGroup.Use(middleware.RateLimitByIP(authLimiter))
 	{
 		authGroup.POST("/admin-login", authHandler.AdminLogin)
 	}
+	api.POST("/admin/mentors/provision", handlers.NewMentorHandler(usecases.NewMentorUseCase(mentorRepo), adminMentorUC, supabaseAdminClient).CreateProvisioned)
 
 	// ---- Feedback (public for students via X-Student-Email header) ----
 	feedbackRepo := repositories.NewFeedbackRepository(db)
@@ -94,7 +103,7 @@ func setupRoutes(engine *gin.Engine, db *gorm.DB, cfg *config.Config) {
 	{
 		// -- Mentors (admin only) --
 		mentorUC := usecases.NewMentorUseCase(mentorRepo)
-		mentorHandler := handlers.NewMentorHandler(mentorUC)
+		mentorHandler := handlers.NewMentorHandler(mentorUC, adminMentorUC, supabaseAdminClient)
 		mentors := protected.Group("/mentors")
 		mentors.Use(middleware.AdminOnly())
 		{

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	JWT       JWTConfig
 	CORS      CORSConfig
 	RateLimit RateLimitConfig
+	Supabase  SupabaseConfig
 }
 
 type ServerConfig struct {
@@ -44,6 +45,11 @@ type RateLimitConfig struct {
 	Enabled       bool
 	Requests      int
 	WindowSeconds int
+}
+
+type SupabaseConfig struct {
+	URL            string
+	ServiceRoleKey string
 }
 
 func Load() *Config {
@@ -77,6 +83,10 @@ func Load() *Config {
 			Enabled:       getEnvBool("RATE_LIMIT_ENABLED", true),
 			Requests:      getEnvInt("RATE_LIMIT_REQUESTS", 100),
 			WindowSeconds: getEnvInt("RATE_LIMIT_WINDOW_SECONDS", 60),
+		},
+		Supabase: SupabaseConfig{
+			URL:            getEnvFirst([]string{"SUPABASE_URL", "VITE_SUPABASE_URL"}, ""),
+			ServiceRoleKey: getEnv("SUPABASE_SERVICE_ROLE_KEY", ""),
 		},
 	}
 }
@@ -113,6 +123,15 @@ func getEnvBool(key string, defaultVal bool) bool {
 		return defaultVal
 	}
 	return val == "true" || val == "1" || val == "yes"
+}
+
+func getEnvFirst(keys []string, defaultVal string) string {
+	for _, key := range keys {
+		if value, exists := os.LookupEnv(key); exists && value != "" {
+			return value
+		}
+	}
+	return defaultVal
 }
 
 type AdminConfig struct {

--- a/backend/internal/dto/mentor_dto.go
+++ b/backend/internal/dto/mentor_dto.go
@@ -4,7 +4,7 @@ type CreateMentorRequest struct {
 	Name           string  `json:"name" binding:"required,min=3"`
 	Email          string  `json:"email" binding:"required,email"`
 	Slug           string  `json:"slug" binding:"required,min=3"`
-	MentorPassword string  `json:"mentor_password" binding:"required,min=4"`
+	Password       string  `json:"password" binding:"required,min=8"`
 	PrimaryColor   string  `json:"primary_color"`
 	SecondaryColor string  `json:"secondary_color"`
 	LogoURL        *string `json:"logo_url"`
@@ -14,7 +14,6 @@ type UpdateMentorRequest struct {
 	Name           string  `json:"name"`
 	Email          string  `json:"email"`
 	Slug           string  `json:"slug"`
-	MentorPassword string  `json:"mentor_password"`
 	PrimaryColor   string  `json:"primary_color"`
 	SecondaryColor string  `json:"secondary_color"`
 	LogoURL        *string `json:"logo_url"`
@@ -28,6 +27,5 @@ type MentorResponse struct {
 	LogoURL        *string `json:"logo_url"`
 	PrimaryColor   string  `json:"primary_color"`
 	SecondaryColor string  `json:"secondary_color"`
-	AccentColor    *string `json:"accent_color"`
 	CreatedAt      string  `json:"created_at"`
 }

--- a/backend/internal/handlers/mentor_handler.go
+++ b/backend/internal/handlers/mentor_handler.go
@@ -1,18 +1,25 @@
 package handlers
 
 import (
+	"log"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/approva-cards/back-aprova-cards/internal/dto"
 	"github.com/approva-cards/back-aprova-cards/internal/usecases"
+	appauth "github.com/approva-cards/back-aprova-cards/pkg/auth"
 	"github.com/gin-gonic/gin"
 )
 
-type MentorHandler struct{ usecase usecases.MentorUseCase }
+type MentorHandler struct {
+	usecase        usecases.MentorUseCase
+	adminUseCase   usecases.AdminMentorUseCase
+	supabaseClient *appauth.SupabaseAdminClient
+}
 
-func NewMentorHandler(usecase usecases.MentorUseCase) *MentorHandler {
-	return &MentorHandler{usecase: usecase}
+func NewMentorHandler(usecase usecases.MentorUseCase, adminUseCase usecases.AdminMentorUseCase, supabaseClient *appauth.SupabaseAdminClient) *MentorHandler {
+	return &MentorHandler{usecase: usecase, adminUseCase: adminUseCase, supabaseClient: supabaseClient}
 }
 
 func (h *MentorHandler) Create(c *gin.Context) {
@@ -69,4 +76,62 @@ func (h *MentorHandler) Delete(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusNoContent, nil)
+}
+
+func (h *MentorHandler) CreateProvisioned(c *gin.Context) {
+	if h.adminUseCase == nil || h.supabaseClient == nil || !h.supabaseClient.IsConfigured() {
+		reason := "admin usecase not initialized"
+		if h.supabaseClient != nil {
+			reason = h.supabaseClient.ConfigDiagnostic()
+		}
+		log.Printf("[mentor-provisioning] unavailable: %s", reason)
+		c.JSON(http.StatusServiceUnavailable, dto.APIResponse{Success: false, Error: "mentor provisioning unavailable", Message: reason})
+		return
+	}
+
+	var req dto.CreateMentorRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, dto.APIResponse{Success: false, Error: err.Error()})
+		return
+	}
+
+	bearerToken := extractBearerToken(c.GetHeader("Authorization"))
+	if bearerToken == "" {
+		log.Printf("[mentor-provisioning] missing bearer token")
+		c.JSON(http.StatusUnauthorized, dto.APIResponse{Success: false, Error: "missing authorization token"})
+		return
+	}
+
+	caller, err := h.supabaseClient.GetUserFromAccessToken(bearerToken)
+	if err != nil {
+		log.Printf("[mentor-provisioning] invalid auth token: %v", err)
+		c.JSON(http.StatusUnauthorized, dto.APIResponse{Success: false, Error: "invalid auth token"})
+		return
+	}
+
+	r, err := h.adminUseCase.CreateMentorByAdmin(&req, caller.Email)
+	if err != nil {
+		log.Printf("[mentor-provisioning] create failed (caller=%s, email=%s): %v", caller.Email, req.Email, err)
+		status := http.StatusBadRequest
+		if strings.Contains(strings.ToLower(err.Error()), "admin access required") {
+			status = http.StatusForbidden
+		}
+		c.JSON(status, dto.APIResponse{Success: false, Error: err.Error()})
+		return
+	}
+
+	log.Printf("[mentor-provisioning] success (caller=%s, mentor_id=%s, mentor_email=%s)", caller.Email, r.ID, r.Email)
+
+	c.JSON(http.StatusCreated, dto.APIResponse{Success: true, Data: r, Message: "Mentor provisioned"})
+}
+
+func extractBearerToken(header string) string {
+	if header == "" {
+		return ""
+	}
+	parts := strings.SplitN(header, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "bearer") {
+		return ""
+	}
+	return strings.TrimSpace(parts[1])
 }

--- a/backend/internal/models/mentor.go
+++ b/backend/internal/models/mentor.go
@@ -8,17 +8,14 @@ import (
 )
 
 type Mentor struct {
-	ID                string    `gorm:"primaryKey;type:uuid" json:"id"`
-	Name              string    `gorm:"not null" json:"name"`
-	Email             string    `gorm:"uniqueIndex" json:"email"`
-	Slug              string    `gorm:"uniqueIndex;not null" json:"slug"`
-	LogoURL           *string   `json:"logo_url"`
-	PrimaryColor      string    `gorm:"not null;default:'#6c63ff'" json:"primary_color"`
-	SecondaryColor    string    `gorm:"not null;default:'#43e97b'" json:"secondary_color"`
-	AccentColor       *string   `gorm:"default:'#ffd166'" json:"accent_color"`
-	MentorPassword    string    `gorm:"not null" json:"-"`
-	KiwifyWebhookToken *string  `json:"-"`
-	CreatedAt         time.Time `gorm:"autoCreateTime" json:"created_at"`
+	ID             string    `gorm:"primaryKey;type:uuid" json:"id"`
+	Name           string    `gorm:"not null" json:"name"`
+	Email          string    `gorm:"uniqueIndex" json:"email"`
+	Slug           string    `gorm:"uniqueIndex;not null" json:"slug"`
+	LogoURL        *string   `json:"logo_url"`
+	PrimaryColor   string    `gorm:"not null;default:'#6c63ff'" json:"primary_color"`
+	SecondaryColor string    `gorm:"not null;default:'#43e97b'" json:"secondary_color"`
+	CreatedAt      time.Time `gorm:"autoCreateTime" json:"created_at"`
 }
 
 func (m *Mentor) BeforeCreate(tx *gorm.DB) error {

--- a/backend/internal/models/user_role.go
+++ b/backend/internal/models/user_role.go
@@ -1,0 +1,16 @@
+package models
+
+import "time"
+
+type UserRole struct {
+	ID        string    `gorm:"primaryKey;type:uuid" json:"id"`
+	Email     string    `gorm:"uniqueIndex;not null" json:"email"`
+	Role      string    `gorm:"not null" json:"role"`
+	MentorID  *string   `gorm:"type:uuid" json:"mentor_id"`
+	ProductID *string   `gorm:"type:uuid" json:"product_id"`
+	Active    bool      `gorm:"not null;default:true" json:"active"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+func (UserRole) TableName() string { return "user_roles" }

--- a/backend/internal/usecases/admin_mentor_usecase.go
+++ b/backend/internal/usecases/admin_mentor_usecase.go
@@ -1,0 +1,152 @@
+package usecases
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/approva-cards/back-aprova-cards/internal/dto"
+	"github.com/approva-cards/back-aprova-cards/internal/models"
+	"github.com/approva-cards/back-aprova-cards/pkg/auth"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type AdminMentorUseCase interface {
+	CreateMentorByAdmin(req *dto.CreateMentorRequest, adminEmail string) (*dto.MentorResponse, error)
+}
+
+type adminMentorUseCase struct {
+	db            *gorm.DB
+	supabaseAdmin *auth.SupabaseAdminClient
+}
+
+func NewAdminMentorUseCase(db *gorm.DB, supabaseAdmin *auth.SupabaseAdminClient) AdminMentorUseCase {
+	return &adminMentorUseCase{db: db, supabaseAdmin: supabaseAdmin}
+}
+
+func (uc *adminMentorUseCase) CreateMentorByAdmin(req *dto.CreateMentorRequest, adminEmail string) (*dto.MentorResponse, error) {
+	if req == nil {
+		return nil, errors.New("invalid request")
+	}
+	if uc.supabaseAdmin == nil || !uc.supabaseAdmin.IsConfigured() {
+		return nil, errors.New("supabase admin integration not configured")
+	}
+
+	normalizedAdminEmail := strings.ToLower(strings.TrimSpace(adminEmail))
+	if normalizedAdminEmail == "" {
+		return nil, errors.New("admin email missing")
+	}
+
+	if err := uc.ensureAdminAccess(normalizedAdminEmail); err != nil {
+		return nil, err
+	}
+
+	normalizedEmail := strings.ToLower(strings.TrimSpace(req.Email))
+	normalizedSlug := strings.ToLower(strings.TrimSpace(req.Slug))
+	if normalizedEmail == "" || normalizedSlug == "" {
+		return nil, errors.New("email and slug are required")
+	}
+
+	var mentorByEmail models.Mentor
+	if err := uc.db.Where("LOWER(email) = ?", normalizedEmail).First(&mentorByEmail).Error; err == nil {
+		return nil, errors.New("mentor email already exists")
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, fmt.Errorf("failed to check mentor email: %w", err)
+	}
+
+	var mentorBySlug models.Mentor
+	if err := uc.db.Where("slug = ?", normalizedSlug).First(&mentorBySlug).Error; err == nil {
+		return nil, errors.New("mentor slug already exists")
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, fmt.Errorf("failed to check mentor slug: %w", err)
+	}
+
+	authUser, err := uc.supabaseAdmin.CreateAuthUser(normalizedEmail, req.Password)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create auth user: %w", err)
+	}
+
+	mentor := &models.Mentor{
+		Name:           strings.TrimSpace(req.Name),
+		Email:          normalizedEmail,
+		Slug:           normalizedSlug,
+		PrimaryColor:   req.PrimaryColor,
+		SecondaryColor: req.SecondaryColor,
+		LogoURL:        req.LogoURL,
+	}
+	if mentor.PrimaryColor == "" {
+		mentor.PrimaryColor = "#6c63ff"
+	}
+	if mentor.SecondaryColor == "" {
+		mentor.SecondaryColor = "#43e97b"
+	}
+
+	tx := uc.db.Begin()
+	if tx.Error != nil {
+		if err := uc.supabaseAdmin.DeleteAuthUser(authUser.ID); err != nil {
+			log.Printf("[mentor-provisioning] failed to delete auth user %s on tx begin error: %v", authUser.ID, err)
+		}
+		return nil, tx.Error
+	}
+
+	if err := tx.Create(mentor).Error; err != nil {
+		tx.Rollback()
+		if delErr := uc.supabaseAdmin.DeleteAuthUser(authUser.ID); delErr != nil {
+			log.Printf("[mentor-provisioning] failed to delete auth user %s on mentor create error: %v", authUser.ID, delErr)
+		}
+		return nil, err
+	}
+
+	mentorID := mentor.ID
+	role := &models.UserRole{
+		ID:       authUser.ID,
+		Email:    normalizedEmail,
+		Role:     "mentor",
+		MentorID: &mentorID,
+		Active:   true,
+	}
+	// Upsert: Supabase may auto-create a user_roles row via trigger on auth.users,
+	// so a duplicate on PK is expected when retrying after a partial failure.
+	if err := tx.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"email", "role", "mentor_id", "active", "updated_at"}),
+	}).Create(role).Error; err != nil {
+		tx.Rollback()
+		if delErr := uc.supabaseAdmin.DeleteAuthUser(authUser.ID); delErr != nil {
+			log.Printf("[mentor-provisioning] failed to delete auth user %s on role create error: %v", authUser.ID, delErr)
+		}
+		return nil, err
+	}
+
+	if err := tx.Commit().Error; err != nil {
+		if delErr := uc.supabaseAdmin.DeleteAuthUser(authUser.ID); delErr != nil {
+			log.Printf("[mentor-provisioning] failed to delete auth user %s on commit error: %v", authUser.ID, delErr)
+		}
+		return nil, err
+	}
+
+	return &dto.MentorResponse{
+		ID:             mentor.ID,
+		Name:           mentor.Name,
+		Email:          mentor.Email,
+		Slug:           mentor.Slug,
+		LogoURL:        mentor.LogoURL,
+		PrimaryColor:   mentor.PrimaryColor,
+		SecondaryColor: mentor.SecondaryColor,
+		CreatedAt:      mentor.CreatedAt.Format("2006-01-02T15:04:05Z"),
+	}, nil
+}
+
+func (uc *adminMentorUseCase) ensureAdminAccess(email string) error {
+	var role models.UserRole
+	err := uc.db.Where("LOWER(email) = ? AND role = ? AND active = ?", email, "admin", true).First(&role).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return errors.New("admin access required")
+		}
+		return err
+	}
+	return nil
+}

--- a/backend/internal/usecases/mentor_usecase.go
+++ b/backend/internal/usecases/mentor_usecase.go
@@ -38,13 +38,16 @@ func (uc *mentorUseCase) Create(req *dto.CreateMentorRequest) (*dto.MentorRespon
 		Name:           req.Name,
 		Email:          req.Email,
 		Slug:           req.Slug,
-		MentorPassword: req.MentorPassword,
 		PrimaryColor:   req.PrimaryColor,
 		SecondaryColor: req.SecondaryColor,
 		LogoURL:        req.LogoURL,
 	}
-	if entity.PrimaryColor == "" { entity.PrimaryColor = "#6c63ff" }
-	if entity.SecondaryColor == "" { entity.SecondaryColor = "#43e97b" }
+	if entity.PrimaryColor == "" {
+		entity.PrimaryColor = "#6c63ff"
+	}
+	if entity.SecondaryColor == "" {
+		entity.SecondaryColor = "#43e97b"
+	}
 
 	if err := uc.repo.Create(entity); err != nil {
 		return nil, err
@@ -54,34 +57,57 @@ func (uc *mentorUseCase) Create(req *dto.CreateMentorRequest) (*dto.MentorRespon
 
 func (uc *mentorUseCase) GetByID(id string) (*dto.MentorResponse, error) {
 	entity, err := uc.repo.GetByID(id)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return mentorToDTO(entity), nil
 }
 
 func (uc *mentorUseCase) GetAll(page, pageSize int) (*dto.PaginatedResponse, error) {
 	entities, total, err := uc.repo.GetAll(page, pageSize)
-	if err != nil { return nil, err }
-	if pageSize < 1 { pageSize = 10 }
+	if err != nil {
+		return nil, err
+	}
+	if pageSize < 1 {
+		pageSize = 10
+	}
 	var responses []dto.MentorResponse
 	for _, e := range entities {
 		responses = append(responses, *mentorToDTO(&e))
 	}
 	totalPages := int(total) / pageSize
-	if int(total)%pageSize > 0 { totalPages++ }
+	if int(total)%pageSize > 0 {
+		totalPages++
+	}
 	return &dto.PaginatedResponse{Data: responses, Total: total, Page: page, PageSize: pageSize, TotalPages: totalPages}, nil
 }
 
 func (uc *mentorUseCase) Update(id string, req *dto.UpdateMentorRequest) (*dto.MentorResponse, error) {
 	entity, err := uc.repo.GetByID(id)
-	if err != nil { return nil, err }
-	if req.Name != "" { entity.Name = req.Name }
-	if req.Email != "" { entity.Email = req.Email }
-	if req.Slug != "" { entity.Slug = req.Slug }
-	if req.MentorPassword != "" { entity.MentorPassword = req.MentorPassword }
-	if req.PrimaryColor != "" { entity.PrimaryColor = req.PrimaryColor }
-	if req.SecondaryColor != "" { entity.SecondaryColor = req.SecondaryColor }
-	if req.LogoURL != nil { entity.LogoURL = req.LogoURL }
-	if err := uc.repo.Update(entity); err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
+	if req.Name != "" {
+		entity.Name = req.Name
+	}
+	if req.Email != "" {
+		entity.Email = req.Email
+	}
+	if req.Slug != "" {
+		entity.Slug = req.Slug
+	}
+	if req.PrimaryColor != "" {
+		entity.PrimaryColor = req.PrimaryColor
+	}
+	if req.SecondaryColor != "" {
+		entity.SecondaryColor = req.SecondaryColor
+	}
+	if req.LogoURL != nil {
+		entity.LogoURL = req.LogoURL
+	}
+	if err := uc.repo.Update(entity); err != nil {
+		return nil, err
+	}
 	return mentorToDTO(entity), nil
 }
 
@@ -93,7 +119,7 @@ func mentorToDTO(e *models.Mentor) *dto.MentorResponse {
 	return &dto.MentorResponse{
 		ID: e.ID, Name: e.Name, Email: e.Email, Slug: e.Slug,
 		LogoURL: e.LogoURL, PrimaryColor: e.PrimaryColor,
-		SecondaryColor: e.SecondaryColor, AccentColor: e.AccentColor,
-		CreatedAt: e.CreatedAt.Format("2006-01-02T15:04:05Z"),
+		SecondaryColor: e.SecondaryColor,
+		CreatedAt:      e.CreatedAt.Format("2006-01-02T15:04:05Z"),
 	}
 }

--- a/backend/pkg/auth/supabase_admin.go
+++ b/backend/pkg/auth/supabase_admin.go
@@ -1,0 +1,206 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type SupabaseAdminClient struct {
+	baseURL        string
+	serviceRoleKey string
+	httpClient     *http.Client
+}
+
+type SupabaseUser struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+}
+
+type createUserRequest struct {
+	Email        string `json:"email"`
+	Password     string `json:"password"`
+	EmailConfirm bool   `json:"email_confirm"`
+}
+
+type createUserResponse struct {
+	User  SupabaseUser `json:"user"`
+	ID    string       `json:"id"`
+	Email string       `json:"email"`
+}
+
+type getUserResponse struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+}
+
+func NewSupabaseAdminClient(baseURL, serviceRoleKey string) *SupabaseAdminClient {
+	cleanBase := normalizeSupabaseBaseURL(baseURL)
+	return &SupabaseAdminClient{
+		baseURL:        cleanBase,
+		serviceRoleKey: serviceRoleKey,
+		httpClient: &http.Client{
+			Timeout: 15 * time.Second,
+		},
+	}
+}
+
+func (c *SupabaseAdminClient) IsConfigured() bool {
+	return c.baseURL != "" && c.serviceRoleKey != ""
+}
+
+func (c *SupabaseAdminClient) ConfigDiagnostic() string {
+	if c.baseURL == "" && c.serviceRoleKey == "" {
+		return "missing SUPABASE_URL (or VITE_SUPABASE_URL) and SUPABASE_SERVICE_ROLE_KEY"
+	}
+	if c.baseURL == "" {
+		return "missing SUPABASE_URL (or VITE_SUPABASE_URL)"
+	}
+	if c.serviceRoleKey == "" {
+		return "missing SUPABASE_SERVICE_ROLE_KEY"
+	}
+	return "ok"
+}
+
+func (c *SupabaseAdminClient) CreateAuthUser(email, password string) (*SupabaseUser, error) {
+	if !c.IsConfigured() {
+		return nil, fmt.Errorf("supabase admin client not configured")
+	}
+
+	payload := createUserRequest{Email: strings.ToLower(strings.TrimSpace(email)), Password: password, EmailConfirm: true}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, statusCode, err := c.doRequest(http.MethodPost, c.baseURL+"/auth/v1/admin/users", bytes.NewReader(body), c.serviceRoleKey)
+	if err != nil {
+		return nil, err
+	}
+	if statusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("supabase create user failed: %s", extractErrorMessage(respBody))
+	}
+
+	var out createUserResponse
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, err
+	}
+
+	created := extractCreatedUser(out)
+	if created.ID == "" {
+		return nil, fmt.Errorf("supabase create user returned empty user id (response=%s)", string(respBody))
+	}
+	return &created, nil
+}
+
+func (c *SupabaseAdminClient) DeleteAuthUser(userID string) error {
+	if !c.IsConfigured() || userID == "" {
+		return nil
+	}
+	respBody, statusCode, err := c.doRequest(http.MethodDelete, c.baseURL+"/auth/v1/admin/users/"+userID, nil, c.serviceRoleKey)
+	if err != nil {
+		return err
+	}
+	if statusCode >= http.StatusBadRequest {
+		return fmt.Errorf("supabase delete user failed: %s", extractErrorMessage(respBody))
+	}
+	return nil
+}
+
+func (c *SupabaseAdminClient) GetUserFromAccessToken(accessToken string) (*SupabaseUser, error) {
+	if !c.IsConfigured() {
+		return nil, fmt.Errorf("supabase admin client not configured")
+	}
+	respBody, statusCode, err := c.doRequest(http.MethodGet, c.baseURL+"/auth/v1/user", nil, accessToken)
+	if err != nil {
+		return nil, err
+	}
+	if statusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("supabase get user failed: %s", extractErrorMessage(respBody))
+	}
+
+	var out getUserResponse
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, err
+	}
+	if out.ID == "" || out.Email == "" {
+		return nil, fmt.Errorf("supabase get user returned invalid payload")
+	}
+	return &SupabaseUser{ID: out.ID, Email: out.Email}, nil
+}
+
+func (c *SupabaseAdminClient) doRequest(method, url string, body io.Reader, bearerToken string) ([]byte, int, error) {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("apikey", c.serviceRoleKey)
+	req.Header.Set("Authorization", "Bearer "+bearerToken)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+	return respBody, resp.StatusCode, nil
+}
+
+func extractErrorMessage(raw []byte) string {
+	if len(raw) == 0 {
+		return "empty response"
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return string(raw)
+	}
+	if msg, ok := payload["msg"].(string); ok && msg != "" {
+		return msg
+	}
+	if msg, ok := payload["message"].(string); ok && msg != "" {
+		return msg
+	}
+	if errStr, ok := payload["error"].(string); ok && errStr != "" {
+		return errStr
+	}
+	return string(raw)
+}
+
+func normalizeSupabaseBaseURL(raw string) string {
+	u := strings.TrimSpace(raw)
+	if u == "" {
+		return ""
+	}
+	u = strings.TrimRight(u, "/")
+	u = strings.TrimSuffix(u, "/rest/v1")
+	u = strings.TrimSuffix(u, "/auth/v1")
+
+	parsed, err := url.Parse(u)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return ""
+	}
+	parsed.Path = ""
+	return strings.TrimRight(parsed.String(), "/")
+}
+
+func extractCreatedUser(out createUserResponse) SupabaseUser {
+	if out.User.ID != "" {
+		return out.User
+	}
+	if out.ID != "" {
+		return SupabaseUser{ID: out.ID, Email: out.Email}
+	}
+	return SupabaseUser{}
+}

--- a/frontend/src/integrations/supabase/client.ts
+++ b/frontend/src/integrations/supabase/client.ts
@@ -2,7 +2,12 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const normalizeSupabaseUrl = (url: string) => {
+  // Accept legacy values like https://<ref>.supabase.co/rest/v1 and normalize to project URL.
+  return url.replace(/\/rest\/v1\/?$/i, '').replace(/\/$/, '');
+};
+
+const SUPABASE_URL = normalizeSupabaseUrl(import.meta.env.VITE_SUPABASE_URL || '');
 const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY;
 
 // Import the supabase client like this:

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -10,6 +10,7 @@ import type { Session } from '@/types';
 
 const SESSION_KEY = 'flashcard_session';
 const SESSION_TTL_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+const ENABLE_EDGE_ADMIN_CHECK = import.meta.env.VITE_ENABLE_EDGE_ADMIN_CHECK === 'true';
 
 export function getSession(): Session | null {
   const raw = localStorage.getItem(SESSION_KEY);
@@ -115,43 +116,25 @@ export async function login(
     onProgress?.('Verificando acesso alternativo...');
 
     // 2. Verificar se é admin via edge function
-    const { data: adminCheck } = await supabase.functions.invoke('check-admin', {
-      body: { email: normalizedEmail, password: trimmedPassword },
-    });
+    if (ENABLE_EDGE_ADMIN_CHECK) {
+      try {
+        const { data: adminCheck } = await supabase.functions.invoke('check-admin', {
+          body: { email: normalizedEmail, password: trimmedPassword },
+        });
 
-    if (adminCheck?.isAdmin) {
-      const session: Session = { email: normalizedEmail, role: 'admin' };
-      setSession(session);
-      return { 
-        session, 
-        redirect: '/admin',
-        accessToken: adminCheck?.token || '',
-        refreshToken: '',
-      };
-    }
-
-    // 3. Verificar mentor (email + mentor_password na tabela mentors)
-    const { data: mentorResult } = await supabase
-      .from('mentors')
-      .select('id, name')
-      .eq('email', normalizedEmail)
-      .eq('mentor_password', trimmedPassword)
-      .maybeSingle();
-
-    if (mentorResult) {
-      const session: Session = { 
-        email: normalizedEmail, 
-        role: 'mentor', 
-        mentor_id: mentorResult.id, 
-        mentor_name: mentorResult.name 
-      };
-      setSession(session);
-      return { 
-        session, 
-        redirect: '/mentor',
-        accessToken: '',
-        refreshToken: '',
-      };
+        if (adminCheck?.isAdmin) {
+          const session: Session = { email: normalizedEmail, role: 'admin' };
+          setSession(session);
+          return {
+            session,
+            redirect: '/admin',
+            accessToken: adminCheck?.token || '',
+            refreshToken: '',
+          };
+        }
+      } catch {
+        // Ignore missing edge function in environments where admin is not validated via Supabase Functions.
+      }
     }
 
     throw new Error('Email ou senha inválidos.');
@@ -175,61 +158,60 @@ export async function login(
     .eq('active', true)
     .maybeSingle();
 
-  if (productResult) {
-    onProgress?.('Verificando acesso do aluno...');
+  // Check user_roles table to get the correct role
+  onProgress?.('Verificando seu perfil...');
+  
+  const { data: userRoleResult } = await supabase
+    .from('user_roles')
+    .select('role, mentor_id, product_id, active')
+    .eq('email', user.email)
+    .maybeSingle();
 
-    // Verificar se email está em student_access
-    const { data: accessResult, error: accessError } = await supabase
-      .from('student_access')
-      .select('id, active')
-      .eq('email', user.email)
-      .eq('product_id', productResult.id)
-      .maybeSingle();
-
-    if (accessError || !accessResult) {
-      throw new Error('E-mail não encontrado no produto. Verifique se usou o e-mail da compra.');
-    }
-
-    if (!accessResult.active) {
-      throw new Error('Seu acesso foi cancelado. Entre em contato com o mentor.');
-    }
-
-    // Obter dados do mentor
-    const { data: mentorData } = await supabase
-      .from('mentors')
-      .select('id, name, primary_color, secondary_color, logo_url')
-      .eq('id', productResult.mentor_id)
-      .maybeSingle();
-
-    onProgress?.('Carregando seu material...');
-
-    const session: Session = {
-      email: user.email || normalizedEmail,
-      role: 'aluno',
-      product_id: productResult.id,
-      mentor_id: mentorData?.id,
-      mentor_name: mentorData?.name,
-    };
-
-    setSession(session);
-    return { 
-      session, 
-      redirect: '/aluno',
-      accessToken,
-      refreshToken: refreshTokenValue,
-    };
+  if (!userRoleResult || !userRoleResult.active) {
+    throw new Error('Seu acesso foi desativado. Entre em contato com o administrador.');
   }
 
-  // Se chegou aqui, é um usuário autenticado Supabase que não é aluno
+  const userRole = (userRoleResult.role as 'aluno' | 'mentor' | 'admin') || 'aluno';
+  let redirectPath = '/aluno';
+  let sessionMentorId: string | undefined;
+  let sessionProductId: string | undefined;
+
+  if (userRole === 'admin') {
+    redirectPath = '/admin';
+  } else if (userRole === 'mentor') {
+    redirectPath = '/mentor';
+    sessionMentorId = userRoleResult.mentor_id || undefined;
+  } else if (userRole === 'aluno' && productResult) {
+    redirectPath = '/aluno';
+    sessionProductId = productResult.id;
+    sessionMentorId = productResult.mentor_id;
+  }
+
+  // Obter dados do mentor se necessário
+  let mentorData = null;
+  if (sessionMentorId) {
+    const { data } = await supabase
+      .from('mentors')
+      .select('id, name, primary_color, secondary_color, logo_url')
+      .eq('id', sessionMentorId)
+      .maybeSingle();
+    mentorData = data;
+  }
+
+  onProgress?.('Carregando seu material...');
+
   const session: Session = {
     email: user.email || normalizedEmail,
-    role: 'aluno', // Default role
+    role: userRole,
+    product_id: sessionProductId,
+    mentor_id: mentorData?.id,
+    mentor_name: mentorData?.name,
   };
 
   setSession(session);
   return { 
     session, 
-    redirect: '/aluno',
+    redirect: redirectPath,
     accessToken,
     refreshToken: refreshTokenValue,
   };

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -72,9 +72,12 @@ const LoginPage: React.FC = () => {
         role: session.role,
         timestamp: new Date().toISOString(),
       });
+      
+      console.log('📍 Redirecionando para:', redirect);
 
       // Redirecionar após breve pausa para o usuário ver o toast
       setTimeout(() => {
+        console.log('⏩ Executando navigate para:', redirect);
         navigate(redirect);
       }, 1500);
     } catch (err: any) {

--- a/frontend/src/pages/admin/AdminMentors.tsx
+++ b/frontend/src/pages/admin/AdminMentors.tsx
@@ -3,7 +3,7 @@ import { useNavigate, Link } from 'react-router-dom';
 import { supabase } from '@/integrations/supabase/client';
 import { getSession } from '@/lib/auth';
 import { AdminLayout } from './AdminDashboard';
-import { Plus, Edit, Trash2, Search, Loader2, Eye, Upload, Copy, Check, AlertTriangle } from 'lucide-react';
+import { Plus, Edit, Trash2, Search, Loader2, Eye, Copy, Check, AlertTriangle } from 'lucide-react';
 
 const AdminMentors: React.FC = () => {
   const navigate = useNavigate();
@@ -12,11 +12,14 @@ const AdminMentors: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [showModal, setShowModal] = useState(false);
+  const [showErrorModal, setShowErrorModal] = useState(false);
+  const [errorModalMessage, setErrorModalMessage] = useState('');
   const [editing, setEditing] = useState<any>(null);
-  const [form, setForm] = useState({ name: '', email: '', slug: '', mentor_password: 'MENTOR2025', primary_color: '#6c63ff', secondary_color: '#43e97b', kiwify_webhook_token: '' });
+  const [form, setForm] = useState({ name: '', email: '', slug: '', password: '', primary_color: '#6c63ff', secondary_color: '#43e97b' });
   const [logoFile, setLogoFile] = useState<File | null>(null);
   const [saving, setSaving] = useState(false);
   const [copiedSlug, setCopiedSlug] = useState<string | null>(null);
+  const slugTooShort = form.slug.trim().length > 0 && form.slug.trim().length < 3;
 
   const baseUrl = window.location.origin;
 
@@ -27,6 +30,20 @@ const AdminMentors: React.FC = () => {
   };
 
   const generateSlug = (name: string) => name.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
+  const getFriendlyErrorMessage = (raw: string) => {
+    const message = (raw || '').toLowerCase();
+    if (message.includes('mentor email already exists')) {
+      return 'Ja existe um mentor com esse e-mail. Use outro e-mail para continuar.';
+    }
+    if (message.includes('email_key') || message.includes('duplicate key')) {
+      return 'Esse e-mail ja esta em uso. Verifique e tente novamente.';
+    }
+    if (message.includes('column "email" of relation "mentors" does not exist')) {
+      return 'Seu banco esta desatualizado: falta a coluna mentors.email. Rode as migrations mais recentes e tente novamente.';
+    }
+    return raw || 'Erro ao salvar mentor.';
+  };
 
   useEffect(() => {
     if (!session || session.role !== 'admin') { navigate('/login'); return; }
@@ -41,41 +58,75 @@ const AdminMentors: React.FC = () => {
 
   const openCreate = () => {
     setEditing(null);
-    setForm({ name: '', email: '', slug: '', mentor_password: 'MENTOR2025', primary_color: '#6c63ff', secondary_color: '#43e97b', kiwify_webhook_token: '' });
+    setForm({ name: '', email: '', slug: '', password: '', primary_color: '#6c63ff', secondary_color: '#43e97b' });
     setLogoFile(null);
     setShowModal(true);
   };
 
   const openEdit = (m: any) => {
     setEditing(m);
-    setForm({ name: m.name, email: m.email || '', slug: m.slug, mentor_password: m.mentor_password, primary_color: m.primary_color, secondary_color: m.secondary_color, kiwify_webhook_token: m.kiwify_webhook_token || '' });
+    setForm({ name: m.name, email: m.email || '', slug: m.slug, password: '', primary_color: m.primary_color, secondary_color: m.secondary_color });
     setLogoFile(null);
     setShowModal(true);
   };
 
   const save = async () => {
     setSaving(true);
-    let logoUrl = editing?.logo_url || null;
+    try {
+      let logoUrl = editing?.logo_url || null;
 
-    if (logoFile) {
-      const ext = logoFile.name.split('.').pop();
-      const path = `${form.slug || 'mentor'}-${Date.now()}.${ext}`;
-      const { error } = await supabase.storage.from('mentor-logos').upload(path, logoFile);
-      if (!error) {
-        const { data: urlData } = supabase.storage.from('mentor-logos').getPublicUrl(path);
-        logoUrl = urlData.publicUrl;
+      if (logoFile) {
+        const ext = logoFile.name.split('.').pop();
+        const path = `${form.slug || 'mentor'}-${Date.now()}.${ext}`;
+        const { error } = await supabase.storage.from('mentor-logos').upload(path, logoFile);
+        if (!error) {
+          const { data: urlData } = supabase.storage.from('mentor-logos').getPublicUrl(path);
+          logoUrl = urlData.publicUrl;
+        }
       }
-    }
 
-    const payload = { ...form, email: form.email || null, kiwify_webhook_token: form.kiwify_webhook_token || null, logo_url: logoUrl };
-    if (editing) {
-      await supabase.from('mentors').update(payload).eq('id', editing.id);
-    } else {
-      await supabase.from('mentors').insert(payload);
+      const payload = { name: form.name, email: form.email || null, slug: form.slug, primary_color: form.primary_color, secondary_color: form.secondary_color, logo_url: logoUrl };
+      if (editing) {
+        await supabase.from('mentors').update(payload).eq('id', editing.id);
+      } else {
+        const { data: sessionData } = await supabase.auth.getSession();
+        const accessToken = sessionData.session?.access_token;
+        if (!accessToken) {
+          throw new Error('Sessao expirada. Faca login novamente como admin.');
+        }
+
+        const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api/v1';
+        const response = await fetch(`${apiBase}/admin/mentors/provision`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${accessToken}`,
+          },
+          body: JSON.stringify({
+            name: form.name,
+            email: form.email,
+            slug: form.slug,
+            password: form.password,
+            primary_color: form.primary_color,
+            secondary_color: form.secondary_color,
+            logo_url: logoUrl,
+          }),
+        });
+
+        const result = await response.json().catch(() => null);
+        if (!response.ok || !result?.success) {
+          throw new Error(result?.error || 'Falha ao provisionar mentor');
+        }
+      }
+
+      setShowModal(false);
+      load();
+    } catch (error: any) {
+      setErrorModalMessage(getFriendlyErrorMessage(error?.message || 'Erro ao salvar mentor'));
+      setShowErrorModal(true);
+    } finally {
+      setSaving(false);
     }
-    setSaving(false);
-    setShowModal(false);
-    load();
   };
 
   const deleteMentor = async (id: string) => {
@@ -117,7 +168,7 @@ const AdminMentors: React.FC = () => {
                       </div>
                       <div className="min-w-0">
                         <p className="font-display font-semibold text-foreground truncate">{m.name}</p>
-                        <p className="text-xs text-muted-foreground truncate">{m.email || 'Sem e-mail'} · <span className="font-mono">{m.mentor_password}</span></p>
+                        <p className="text-xs text-muted-foreground truncate">{m.email || 'Sem e-mail'}</p>
                       </div>
                     </div>
                     <div className="flex gap-1 shrink-0">
@@ -186,8 +237,10 @@ const AdminMentors: React.FC = () => {
               <label className="mb-1 block text-xs font-medium text-muted-foreground">Slug (URL)</label>
               <input type="text" value={form.slug}
                 onChange={e => setForm(f => ({ ...f, slug: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '') }))}
-                className="w-full rounded-xl border border-border bg-surface px-4 py-2.5 text-foreground font-mono focus:border-primary focus:outline-none transition-colors" />
-              <p className="mt-1 text-[11px] text-muted-foreground">Gerado automaticamente a partir do nome</p>
+                className={`w-full rounded-xl border bg-surface px-4 py-2.5 text-foreground font-mono focus:border-primary focus:outline-none transition-colors ${slugTooShort ? 'border-destructive' : 'border-border'}`} />
+              <p className={`mt-1 text-[11px] ${slugTooShort ? 'text-destructive' : 'text-muted-foreground'}`}>
+                {slugTooShort ? 'Slug deve ter pelo menos 3 caracteres.' : 'Gerado automaticamente a partir do nome (minimo 3 caracteres).'}
+              </p>
             </div>
             
             {/* E-mail */}
@@ -200,13 +253,15 @@ const AdminMentors: React.FC = () => {
               <p className="mt-1 text-[11px] text-muted-foreground">Usado no login do painel mentor</p>
             </div>
             
-            {/* Senha */}
-            <div>
-              <label className="mb-1 block text-xs font-medium text-muted-foreground">Senha do mentor</label>
-              <input type="text" value={form.mentor_password}
-                onChange={e => setForm(f => ({ ...f, mentor_password: e.target.value }))}
-                className="w-full rounded-xl border border-border bg-surface px-4 py-2.5 text-foreground font-mono focus:border-primary focus:outline-none transition-colors" />
-            </div>
+            {!editing && (
+              <div>
+                <label className="mb-1 block text-xs font-medium text-muted-foreground">Senha de acesso (Auth)</label>
+                <input type="password" value={form.password}
+                  onChange={e => setForm(f => ({ ...f, password: e.target.value }))}
+                  className="w-full rounded-xl border border-border bg-surface px-4 py-2.5 text-foreground font-mono focus:border-primary focus:outline-none transition-colors" />
+                <p className="mt-1 text-[11px] text-muted-foreground">A senha sera criada no Supabase Auth e nao armazenada em plaintext.</p>
+              </div>
+            )}
             
             {/* Cores */}
             <div className="flex gap-4">
@@ -236,22 +291,29 @@ const AdminMentors: React.FC = () => {
               )}
             </div>
             
-            {/* Token Webhook */}
-            <div>
-              <label className="mb-1 block text-xs font-medium text-muted-foreground">Token Webhook Kiwify</label>
-              <input type="text" value={form.kiwify_webhook_token}
-                onChange={e => setForm(f => ({ ...f, kiwify_webhook_token: e.target.value }))}
-                className="w-full rounded-xl border border-border bg-surface px-4 py-2.5 text-foreground font-mono focus:border-primary focus:outline-none transition-colors"
-                placeholder="Cole aqui o token do webhook" />
-              <p className="mt-1 text-[11px] text-muted-foreground">Após criar o webhook na Kiwify (Apps → Webhooks), copie o token gerado e cole aqui</p>
-            </div>
-            
             <div className="flex gap-2 pt-1">
-              <button onClick={save} disabled={saving || !form.name || !form.slug}
+              <button onClick={save} disabled={saving || !form.name || !form.slug || form.slug.trim().length < 3 || (!editing && !form.password)}
                 className="flex-1 flex items-center justify-center gap-2 rounded-xl bg-primary py-3 font-medium text-primary-foreground disabled:opacity-50">
                 {saving && <Loader2 className="h-4 w-4 animate-spin" />} Salvar
               </button>
               <button onClick={() => setShowModal(false)} className="flex-1 rounded-xl border border-border py-3 font-medium text-foreground">Cancelar</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showErrorModal && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 p-4" onClick={() => setShowErrorModal(false)}>
+          <div className="w-full max-w-md rounded-2xl border border-border bg-card p-6" onClick={e => e.stopPropagation()}>
+            <h3 className="font-display text-lg font-semibold text-foreground">Nao foi possivel salvar o mentor</h3>
+            <p className="mt-3 text-sm text-muted-foreground">{errorModalMessage}</p>
+            <div className="mt-5 flex justify-end">
+              <button
+                onClick={() => setShowErrorModal(false)}
+                className="rounded-xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+              >
+                Entendi
+              </button>
             </div>
           </div>
         </div>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,8 @@ import react from "@vitejs/plugin-react-swc";
 import path from "path";
 
 export default defineConfig(({ mode }) => ({
+  // Monorepo: load .env from repository root
+  envDir: path.resolve(__dirname, ".."),
   build: {
     outDir: "dist",
     sourcemap: mode !== "production",

--- a/supabase/migrations/20260425142000_remove_mentor_password.sql
+++ b/supabase/migrations/20260425142000_remove_mentor_password.sql
@@ -1,0 +1,6 @@
+-- Move mentor authentication to Supabase Auth and stop storing plaintext mentor passwords.
+DROP TRIGGER IF EXISTS check_mentor_password ON public.mentors;
+DROP FUNCTION IF EXISTS public.validate_unique_mentor_password();
+
+ALTER TABLE public.mentors
+  DROP COLUMN IF EXISTS mentor_password;

--- a/supabase/migrations/20260425150000_add_mentors_email_if_missing.sql
+++ b/supabase/migrations/20260425150000_add_mentors_email_if_missing.sql
@@ -1,0 +1,16 @@
+-- Defensive migration for environments that missed older email migration.
+ALTER TABLE public.mentors
+  ADD COLUMN IF NOT EXISTS email text;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'mentors_email_key'
+  ) THEN
+    CREATE UNIQUE INDEX mentors_email_key ON public.mentors (email);
+  END IF;
+END
+$$;


### PR DESCRIPTION
Migra criação de mentores para Supabase Auth: admin provisiona mentor com email/senha, cria user_roles com upsert para tolerar triggers externos, e remove armazenamento de mentor_password do banco.